### PR TITLE
Additional project date fields

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/project/Project.java
+++ b/src/main/java/org/humancellatlas/ingest/project/Project.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 import org.humancellatlas.ingest.core.EntityType;
 import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.file.File;
@@ -12,6 +13,7 @@ import org.springframework.data.mongodb.core.mapping.DBRef;
 import org.springframework.data.rest.core.annotation.RestResource;
 
 import javax.validation.constraints.NotNull;
+import java.time.Instant;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -35,6 +37,12 @@ public class Project extends MetadataDocument {
     private @DBRef(lazy = true)
     Set<SubmissionEnvelope> submissionEnvelopes = new HashSet<>();
 
+    @Setter
+    private Instant releaseDate;
+
+    @Setter
+    private Instant accessionDate;
+
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public Project(Object content) {
         super(EntityType.PROJECT, content);
@@ -46,15 +54,15 @@ public class Project extends MetadataDocument {
 
     //ToDo: Find a better way of ensuring that DBRefs to deleted objects aren't returned.
     @JsonIgnore
-    public List<SubmissionEnvelope> getOpenSubmissionEnvelopes(){
+    public List<SubmissionEnvelope> getOpenSubmissionEnvelopes() {
         return this.submissionEnvelopes.stream()
-            .filter(Objects::nonNull)
-            .filter(env -> env.getSubmissionState() != null)
-            .filter(SubmissionEnvelope::isOpen)
-            .collect(Collectors.toList());
+                .filter(Objects::nonNull)
+                .filter(env -> env.getSubmissionState() != null)
+                .filter(SubmissionEnvelope::isOpen)
+                .collect(Collectors.toList());
     }
 
-    public Boolean getHasOpenSubmission(){
+    public Boolean getHasOpenSubmission() {
         return !getOpenSubmissionEnvelopes().isEmpty();
     }
 


### PR DESCRIPTION
Ingest needs to support additional project fields which are outside the metadata schema:
1. release date - The date that should be passed to DSP API when project is released in the BioStudies
2. accession date - The date for archiving and getting accessions

Related UI changes - https://github.com/ebi-ait/ingest-ui/pull/10

These are not considered part of the project metadata due to following reasons:
1. These fields are internal ingest/EBI concerns.
2. These fields are irrelevant after the data has been released.
3. These are bits of information from the contributor so we can help them submit their data in the way they expect rather than bits of metadata about the process

slack thread: https://embl-ebi-ait.slack.com/archives/C0103DEJ82C/p1588846317008400