### PR TITLE
Check issuer first before running Elixir Authentication

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/security/authn/provider/elixir/ElixirAaiAuthenticationProvider.java
+++ b/src/main/java/org/humancellatlas/ingest/security/authn/provider/elixir/ElixirAaiAuthenticationProvider.java
@@ -50,12 +50,14 @@ public class ElixirAaiAuthenticationProvider implements AuthenticationProvider {
         }
         try {
             JwtAuthentication jwt = (JwtAuthentication) authentication;
+            String token = jwt.getToken();
+            String issuer = JWT.decode(token).getIssuer();
+            verifyIssuer(issuer);
+
             JWTVerifier jwtVerifier = jwtVerifierResolver.resolve(jwt.getToken());
             DelegatingJwtAuthentication verifiedAuth = DelegatingJwtAuthentication.delegate(jwt, jwtVerifier);
 
-            String token = verifiedAuth.getToken();
-            String issuer = JWT.decode(token).getIssuer();
-            verifyIssuer(issuer);
+            token = verifiedAuth.getToken();
             UserInfo userInfo = retrieveUserInfo(token);
             validateEmail(userInfo);
 


### PR DESCRIPTION
A better solution is to have a JWT authentication filter and have an authentication manager to select which auth provider should authenticate the token.

https://stackoverflow.com/questions/984644/spring-authentication-provider-vs-authentication-processing-filter