### PR TITLE
Cascade ArchiveSubmission deletes

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/archiving/entity/ArchiveEntityRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/archiving/entity/ArchiveEntityRepository.java
@@ -4,6 +4,7 @@ import org.humancellatlas.ingest.archiving.submission.ArchiveSubmission;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.rest.core.annotation.RestResource;
 import org.springframework.web.bind.annotation.CrossOrigin;
 
 @CrossOrigin
@@ -19,5 +20,7 @@ public interface ArchiveEntityRepository extends MongoRepository<ArchiveEntity, 
     Page<ArchiveEntity> findByArchiveSubmissionAndType(ArchiveSubmission archiveSubmission,
                                                        ArchiveEntityType archiveEntityType,
                                                        Pageable pageable);
+    @RestResource(exported = false)
+    Long deleteByArchiveSubmission(ArchiveSubmission archiveSubmission);
 
 }

--- a/src/main/java/org/humancellatlas/ingest/archiving/submission/web/ArchiveSubmissionController.java
+++ b/src/main/java/org/humancellatlas/ingest/archiving/submission/web/ArchiveSubmissionController.java
@@ -48,4 +48,11 @@ public class ArchiveSubmissionController {
         Page<ArchiveEntity> archiveEntities = archiveEntityRepository.findByArchiveSubmission(archiveSubmission, pageable);
         return ResponseEntity.ok(pagedResourcesAssembler.toResource(archiveEntities, resourceAssembler));
     }
+
+    @RequestMapping(path = "archiveSubmissions/{sub_id}", method = RequestMethod.DELETE)
+    ResponseEntity deleteSubmission(@PathVariable("sub_id") ArchiveSubmission archiveSubmission) {
+        archiveEntityRepository.deleteByArchiveSubmission(archiveSubmission);
+        archiveSubmissionRepository.delete(archiveSubmission);
+        return ResponseEntity.accepted().build();
+    }
 }


### PR DESCRIPTION
Implementation for Stretch Goal of [#255](https://github.com/ebi-ait/hca-ebi-dev-team/issues/255)

Deleting an Archive Submission first deletes the entities that are linked to it.

Deployed & Tested on [Dev](https://api.ingest.dev.archive.data.humancellatlas.org/browser/index.html#https://api.ingest.dev.archive.data.humancellatlas.org/archiveSubmissions) 