### PR TITLE
Use assay process uuid as the bundle uuid in the exporter message

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/core/MetadataDocumentMessageBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/core/MetadataDocumentMessageBuilder.java
@@ -28,6 +28,7 @@ public class MetadataDocumentMessageBuilder {
     private String metadataDocUuid;
     private String envelopeId;
     private String envelopeUuid;
+    private Instant metadataDocVersion;
     private ValidationState validationState;
     private int assayIndex;
     private int totalAssays;
@@ -53,6 +54,7 @@ public class MetadataDocumentMessageBuilder {
         if (metadataDocumentUuid != null && metadataDocumentUuid.getUuid() != null) {
             builder = builder.withUuid(metadataDocument.getUuid().getUuid().toString());
         }
+        builder = builder.withVersion(metadataDocument.getDcpVersion());
 
         return builder;
     }
@@ -71,6 +73,12 @@ public class MetadataDocumentMessageBuilder {
 
     private MetadataDocumentMessageBuilder withUuid(String metadataDocUuid) {
         this.metadataDocUuid = metadataDocUuid;
+
+        return this;
+    }
+
+    private MetadataDocumentMessageBuilder withVersion(Instant metadataDocVersion) {
+        this.metadataDocVersion = metadataDocVersion;
 
         return this;
     }
@@ -113,7 +121,7 @@ public class MetadataDocumentMessageBuilder {
 
     public ExportMessage buildExperimentSubmittedMessage(ExportJob exportJob) {
         String callbackLink = linkGenerator.createCallback(documentType, metadataDocId);
-        return new ExportMessage(UUID.fromString(metadataDocUuid), Instant.now().toString(), messageProtocol, exportJob.getId(), metadataDocId, metadataDocUuid, callbackLink,
+        return new ExportMessage(UUID.fromString(metadataDocUuid), metadataDocVersion.toString(), messageProtocol, exportJob.getId(), metadataDocId, metadataDocUuid, callbackLink,
                 documentType.getSimpleName(), envelopeId, envelopeUuid, assayIndex, totalAssays);
     }
 

--- a/src/main/java/org/humancellatlas/ingest/core/MetadataDocumentMessageBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/core/MetadataDocumentMessageBuilder.java
@@ -57,20 +57,6 @@ public class MetadataDocumentMessageBuilder {
         return builder;
     }
 
-    public MetadataDocumentMessageBuilder messageFor(BundleManifest bundleManifest) {
-        MetadataDocumentMessageBuilder builder = withDocumentType(bundleManifest.getClass())
-                .withId(bundleManifest.getId())
-                .withUuid(bundleManifest.getBundleUuid().toString());
-
-        return builder;
-    }
-
-    public MetadataDocumentMessageBuilder withMessageProtocol(MessageProtocol messageProtocol) {
-        this.messageProtocol = messageProtocol;
-
-        return this;
-    }
-
     private <T extends Identifiable> MetadataDocumentMessageBuilder withDocumentType(
             Class<T> documentClass) {
         this.documentType = documentClass;
@@ -127,7 +113,7 @@ public class MetadataDocumentMessageBuilder {
 
     public ExportMessage buildExperimentSubmittedMessage(ExportJob exportJob) {
         String callbackLink = linkGenerator.createCallback(documentType, metadataDocId);
-        return new ExportMessage(UUID.randomUUID(), Instant.now().toString(), messageProtocol, exportJob.getId(), metadataDocId, metadataDocUuid, callbackLink,
+        return new ExportMessage(UUID.fromString(metadataDocUuid), Instant.now().toString(), messageProtocol, exportJob.getId(), metadataDocId, metadataDocUuid, callbackLink,
                 documentType.getSimpleName(), envelopeId, envelopeUuid, assayIndex, totalAssays);
     }
 

--- a/src/test/java/org/humancellatlas/ingest/messaging/MessageRouterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/messaging/MessageRouterTest.java
@@ -123,6 +123,8 @@ public class MessageRouterTest {
         Process process = new Process(processId);
         Uuid processUuid = Uuid.newUuid();
         process.setUuid(processUuid);
+        Instant version = Instant.now();
+        process.setDcpVersion(version);
 
         //and:
         String envelopeId = "87bcf3";


### PR DESCRIPTION
To avoid having multiple set of bundle uuids/ experiment link.json files