### PR TITLE
Make Singleton: project.dataAccess.type

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
+++ b/src/main/java/org/humancellatlas/ingest/migrations/MongoChangeLog.java
@@ -98,4 +98,12 @@ public class MongoChangeLog {
             }
         }
     }
+
+    @ChangeSet(order = "2020-09-15", id = "singelton project.dataAccess.type", author = "alexie.staffer@ebi.ac.uk")
+    public void singeltonProjectDataAccessType(MongoDatabase db) {
+        Document filter = Document.parse("{'dataAccess.type': {$type: 'array'}}");
+        List<Document> update = new ArrayList<>();
+        update.add(new Document("$set", Document.parse("{ 'dataAccess.type': { $arrayElemAt: [ '$dataAccess.type', 0 ] } }")));
+        db.getCollection("project").updateMany(filter, update);
+    }
 }


### PR DESCRIPTION
Required for [ingest-ui#52](https://github.com/ebi-ait/ingest-ui/pull/52#issuecomment-696689835)
Migrates existing project.dataAccess.type data from arrays to singelton.