### PR TITLE
Partial Project update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ nbdist/
 out
 bin/
 .vscode/
+.DS_Store

--- a/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
@@ -1,6 +1,7 @@
 package org.humancellatlas.ingest.project.web;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.data.MapEntry;
 import org.humancellatlas.ingest.config.MigrationConfiguration;
 import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.project.ProjectRepository;
@@ -71,7 +72,12 @@ class ProjectControllerTest {
             //Using Map here because reading directly to Project converts the entire JSON to Project.content.
             Map<String, Object> updated = objectMapper.readValue(response.getContentAsString(), Map.class);
             assertThat(updated.get("content")).isInstanceOf(Map.class);
-            assertThat((Map) updated.get("content")).containsOnly(entry("description", "test updated"));
+            MapEntry<String, String> updatedDescription = entry("description", "test updated");
+            assertThat((Map) updated.get("content")).containsOnly(updatedDescription);
+
+            //and:
+            project = repository.findById(project.getId()).get();
+            assertThat((Map) project.getContent()).containsOnly(updatedDescription);
         }
 
     }

--- a/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
@@ -4,14 +4,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.assertj.core.data.MapEntry;
 import org.humancellatlas.ingest.config.MigrationConfiguration;
 import org.humancellatlas.ingest.project.Project;
+import org.humancellatlas.ingest.project.ProjectEventHandler;
 import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.schemas.SchemaService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,9 +22,12 @@ import org.springframework.test.web.servlet.MvcResult;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.Consumer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 
@@ -38,6 +44,9 @@ class ProjectControllerTest {
     @Autowired
     private ObjectMapper objectMapper;
 
+    @SpyBean
+    private ProjectEventHandler projectEventHandler;
+
     @MockBean
     private MigrationConfiguration migrationConfiguration;
 
@@ -48,7 +57,23 @@ class ProjectControllerTest {
     class Update {
 
         @Test
+        void updateSuccess() throws Exception {
+            doTestUpdate("/projects/{id}", project -> {
+                var projectCaptor = ArgumentCaptor.forClass(Project.class);
+                verify(projectEventHandler).editedProjectMetadata(projectCaptor.capture());
+                Project handledProject = projectCaptor.getValue();
+                assertThat(handledProject.getId()).isEqualTo(project.getId());
+            });
+        }
+
+        @Test
         void partialUpdateSuccess() throws Exception {
+            doTestUpdate("/projects/{id}?partial=true", project -> {
+                verify(projectEventHandler, never()).editedProjectMetadata(any());
+            });
+        }
+
+        private void doTestUpdate(String patchUrl, Consumer<Project> postCondition) throws Exception {
             //given:
             var content = new HashMap<String, Object>();
             content.put("description", "test");
@@ -58,7 +83,7 @@ class ProjectControllerTest {
             //when:
             content.put("description", "test updated");
             MvcResult result = webApp
-                    .perform(patch("/projects/{id}?partial=true", project.getId())
+                    .perform(patch(patchUrl, project.getId())
                             .contentType(APPLICATION_JSON_VALUE)
                             .content("{\"content\": " + objectMapper.writeValueAsString(content) + "}"))
                     .andReturn();
@@ -78,6 +103,9 @@ class ProjectControllerTest {
             //and:
             project = repository.findById(project.getId()).get();
             assertThat((Map) project.getContent()).containsOnly(updatedDescription);
+
+            //and:
+            postCondition.accept(project);
         }
 
     }

--- a/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
@@ -1,7 +1,9 @@
 package org.humancellatlas.ingest.project.web;
 
-import org.assertj.core.api.Assertions;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.humancellatlas.ingest.config.MigrationConfiguration;
+import org.humancellatlas.ingest.project.Project;
+import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.schemas.SchemaService;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -10,9 +12,16 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 
 @SpringBootTest
@@ -22,6 +31,12 @@ class ProjectControllerTest {
     @Autowired
     private MockMvc webApp;
 
+    @Autowired
+    private ProjectRepository repository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
     @MockBean
     private MigrationConfiguration migrationConfiguration;
 
@@ -29,17 +44,34 @@ class ProjectControllerTest {
     private SchemaService schemaService;
 
     @Nested
-    class PartialUpdate {
+    class Update {
 
         @Test
-        void midStepSuccess() throws Exception {
+        void partialUpdateSuccess() throws Exception {
             //given:
+            var content = new HashMap<String, Object>();
+            content.put("description", "test");
+            Project project = new Project(content);
+            project = repository.save(project);
+
+            //when:
+            content.put("description", "test updated");
             MvcResult result = webApp
-                    .perform(patch("/projects?step={step}&totalSteps={steps}", 1, 2))
+                    .perform(patch("/projects/{id}?partial=true", project.getId())
+                            .contentType(APPLICATION_JSON_VALUE)
+                            .content("{\"content\": " + objectMapper.writeValueAsString(content) + "}"))
                     .andReturn();
 
             //expect:
-            Assertions.assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.OK.value());
+            MockHttpServletResponse response = result.getResponse();
+            assertThat(response.getStatus()).isEqualTo(HttpStatus.OK.value());
+            assertThat(response.getContentType()).containsPattern("application/.*json.*");
+
+            //and:
+            //Using Map here because reading directly to Project converts the entire JSON to Project.content.
+            Map<String, Object> updated = objectMapper.readValue(response.getContentAsString(), Map.class);
+            assertThat(updated.get("content")).isInstanceOf(Map.class);
+            assertThat((Map) updated.get("content")).containsOnly(entry("description", "test updated"));
         }
 
     }

--- a/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
@@ -1,0 +1,47 @@
+package org.humancellatlas.ingest.project.web;
+
+import org.assertj.core.api.Assertions;
+import org.humancellatlas.ingest.config.MigrationConfiguration;
+import org.humancellatlas.ingest.schemas.SchemaService;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+
+@SpringBootTest
+@AutoConfigureMockMvc(printOnlyOnFailure = false)
+class ProjectControllerTest {
+
+    @Autowired
+    private MockMvc webApp;
+
+    @MockBean
+    private MigrationConfiguration migrationConfiguration;
+
+    @MockBean
+    private SchemaService schemaService;
+
+    @Nested
+    class PartialUpdate {
+
+        @Test
+        void midStepSuccess() throws Exception {
+            //given:
+            MvcResult result = webApp
+                    .perform(patch("/projects?step={step}&totalSteps={steps}", 1, 2))
+                    .andReturn();
+
+            //expect:
+            Assertions.assertThat(result.getResponse().getStatus()).isEqualTo(HttpStatus.OK.value());
+        }
+
+    }
+
+}

--- a/src/main/java/org/humancellatlas/ingest/patch/JsonPatcher.java
+++ b/src/main/java/org/humancellatlas/ingest/patch/JsonPatcher.java
@@ -1,0 +1,29 @@
+package org.humancellatlas.ingest.patch;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mapping.context.PersistentEntities;
+import org.springframework.data.rest.webmvc.json.DomainObjectReader;
+import org.springframework.data.rest.webmvc.mapping.Associations;
+import org.springframework.stereotype.Component;
+
+import java.io.InputStream;
+
+@Component
+public class JsonPatcher {
+
+    private final DomainObjectReader domainObjectReader;
+
+    private final ObjectMapper objectMapper;
+
+    @Autowired
+    public JsonPatcher(PersistentEntities persistentEntities, Associations associations, ObjectMapper objectMapper) {
+        this.domainObjectReader = new DomainObjectReader(persistentEntities, associations);
+        this.objectMapper = objectMapper;
+    }
+
+    public <T> T merge(InputStream patch, T target) {
+        return domainObjectReader.read(patch, target, objectMapper);
+    }
+
+}

--- a/src/main/java/org/humancellatlas/ingest/patch/JsonPatcher.java
+++ b/src/main/java/org/humancellatlas/ingest/patch/JsonPatcher.java
@@ -1,14 +1,16 @@
 package org.humancellatlas.ingest.patch;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.mapping.context.PersistentEntities;
 import org.springframework.data.rest.webmvc.json.DomainObjectReader;
 import org.springframework.data.rest.webmvc.mapping.Associations;
 import org.springframework.stereotype.Component;
 
-import java.io.InputStream;
-
+/**
+ * Utility class mainly for applying patches to domain objects.
+ */
 @Component
 public class JsonPatcher {
 
@@ -22,8 +24,13 @@ public class JsonPatcher {
         this.objectMapper = objectMapper;
     }
 
-    public <T> T merge(InputStream patch, T target) {
-        return domainObjectReader.read(patch, target, objectMapper);
+    /*
+    Almost the same exact implementation used in {@link org.springframework.data.rest.webmvc.config.JsonPatchHandler}
+    to merge JSON documents for Spring Data REST. It's copied here because the patch code that Spring uses was made
+    internal to the framework.
+     */
+    public <T> T merge(ObjectNode patch, T target) {
+        return domainObjectReader.merge(patch, target, objectMapper);
     }
 
 }

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectChangeListener.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectChangeListener.java
@@ -24,7 +24,6 @@ public class ProjectChangeListener extends AbstractMongoEventListener<Project> {
 
     @Override
     public void onAfterSave(AfterSaveEvent<Project> event) {
-        Project project = event.getSource();
-        projectEventHandler.editedProjectMetadata(project);
+        //do nothing
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
@@ -25,7 +25,7 @@ import java.util.stream.Stream;
  * @date 31/08/17
  */
 @CrossOrigin
-public interface ProjectRepository extends MongoRepository<Project, String> , ProjectRepositoryCustom{
+public interface ProjectRepository extends MongoRepository<Project, String> , ProjectRepositoryCustom {
 
     @RestResource(rel = "findAllByUuid", path = "findAllByUuid")
     Page<Project> findByUuid(@Param("uuid") Uuid uuid, Pageable pageable);

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
@@ -66,6 +66,10 @@ public class ProjectService {
         return persistentProject;
     }
 
+    public void partialUpdate(String id, Project update) {
+        projectRepository.save(update);
+    }
+
     public Project addProjectToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Project project) {
         if(! project.getIsUpdate()) {
             return metadataCrudService.addToSubmissionEnvelopeAndSave(project, submissionEnvelope);

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
@@ -66,10 +66,6 @@ public class ProjectService {
         return persistentProject;
     }
 
-    public void partialUpdate(String id, Project update) {
-        projectRepository.save(update);
-    }
-
     public Project addProjectToSubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Project project) {
         if(! project.getIsUpdate()) {
             return metadataCrudService.addToSubmissionEnvelopeAndSave(project, submissionEnvelope);

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -53,6 +53,11 @@ public class ProjectController {
         return ResponseEntity.ok().body(assembler.toFullResource(result));
     }
 
+    @PatchMapping("/projects")
+    ResponseEntity<Resource> update() {
+        return ResponseEntity.ok(null);
+    }
+
     @PostMapping(path = "submissionEnvelopes/{sub_id}/projects")
     ResponseEntity<Resource<?>> addProjectToEnvelope(
             @PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -9,6 +9,7 @@ import org.humancellatlas.ingest.bundle.BundleType;
 import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.patch.JsonPatcher;
 import org.humancellatlas.ingest.project.Project;
+import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.project.ProjectService;
 import org.humancellatlas.ingest.project.exception.NonEmptyProject;
 import org.humancellatlas.ingest.query.MetadataCriteria;
@@ -50,6 +51,8 @@ public class ProjectController {
     private final @NonNull ProjectService projectService;
     private final @NonNull PagedResourcesAssembler pagedResourcesAssembler;
 
+    private final @NonNull ProjectRepository projectRepository;
+
     private final @NonNull JsonPatcher jsonPatcher;
 
     @PostMapping("/projects")
@@ -60,9 +63,10 @@ public class ProjectController {
     }
 
     @PatchMapping("/projects/{id}")
-    ResponseEntity<Resource<?>> update(@PathVariable("id") Project project, @RequestBody ObjectNode patch,
+    ResponseEntity<Resource<?>> update(@PathVariable("id") final Project project, @RequestBody final ObjectNode patch,
             final PersistentEntityResourceAssembler assembler) {
         jsonPatcher.merge(patch, project);
+        projectRepository.save(project);
         return ResponseEntity.ok().body(assembler.toFullResource(project));
     }
 

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -1,5 +1,6 @@
 package org.humancellatlas.ingest.project.web;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -59,14 +60,10 @@ public class ProjectController {
     }
 
     @PatchMapping("/projects/{id}")
-    ResponseEntity<Resource<?>> update(@PathVariable("id") Project project, HttpServletRequest request,
+    ResponseEntity<Resource<?>> update(@PathVariable("id") Project project, @RequestBody ObjectNode patch,
             final PersistentEntityResourceAssembler assembler) {
-        try {
-            jsonPatcher.merge(request.getInputStream(), project);
-            return ResponseEntity.ok().body(assembler.toFullResource(project));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        jsonPatcher.merge(patch, project);
+        return ResponseEntity.ok().body(assembler.toFullResource(project));
     }
 
     @PostMapping(path = "submissionEnvelopes/{sub_id}/projects")

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
@@ -21,6 +21,9 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
@@ -28,6 +31,7 @@ import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
@@ -172,6 +176,36 @@ public class ProjectServiceTest {
             verify(projectRepository).save(project);
             assertThat(result).isEqualTo(persistentProject);
             verify(projectEventHandler).registeredProject(persistentProject);
+        }
+
+    }
+
+    @Nested
+    class Update {
+
+        @Test
+        @DisplayName("partial update succeeds")
+        void partialUpdateSuccess() {
+            //given:
+            String id = "78bcb901";
+            var content = Map.of(
+                    "name", "sample",
+                    "description", "test"
+            );
+            Project project = new Project(content);
+            doReturn(Optional.of(project)).when(projectRepository).findById(id);
+
+            //and:
+            var updatedContent = new HashMap<String, Object>();
+            updatedContent.putAll(content);
+            updatedContent.put("name", "updated sample");
+            Project updatedProject = new Project(updatedContent);
+
+            //when:
+            projectService.partialUpdate(id, updatedProject);
+
+            //then:
+            verify(projectRepository).save(any(Project.class));
         }
 
     }

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
@@ -21,17 +21,12 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Optional;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 
@@ -176,36 +171,6 @@ public class ProjectServiceTest {
             verify(projectRepository).save(project);
             assertThat(result).isEqualTo(persistentProject);
             verify(projectEventHandler).registeredProject(persistentProject);
-        }
-
-    }
-
-    @Nested
-    class Update {
-
-        @Test
-        @DisplayName("partial update succeeds")
-        void partialUpdateSuccess() {
-            //given:
-            String id = "78bcb901";
-            var content = Map.of(
-                    "name", "sample",
-                    "description", "test"
-            );
-            Project project = new Project(content);
-            doReturn(Optional.of(project)).when(projectRepository).findById(id);
-
-            //and:
-            var updatedContent = new HashMap<String, Object>();
-            updatedContent.putAll(content);
-            updatedContent.put("name", "updated sample");
-            Project updatedProject = new Project(updatedContent);
-
-            //when:
-            projectService.partialUpdate(id, updatedProject);
-
-            //then:
-            verify(projectRepository).save(any(Project.class));
         }
 
     }


### PR DESCRIPTION
Restructured the update endpoint for Projects so that operations can be flagged as partial. Partial updates refer to patching operations that are part of a larger series of updates. For now, partial updates are nothing more than a flagging system with the goal of making notification less noisy. However, in the future, partial updates can be further modified to keep track of update sessions and group together patches that are part of a bigger update transaction. This might be useful for transactional rollbacks, more descriptive notification messages, etc.