### PR TITLE
Updated submission protocol endpoint to display linking status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
       - name: Display Gradle environment
         run: ./gradlew -v
       - name: Gradle verification
-        run: ./gradlew verify
+        run: ./gradlew clean verify

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   verify:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   verify:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
@@ -53,4 +53,8 @@ public interface ProcessRepository extends MongoRepository<Process, String> {
     Stream<Process> findByProtocolsContains(Protocol protocol);
 
     Stream<Process> findByInputBundleManifestsContains(BundleManifest bundleManifest);
+
+    @RestResource(exported = false)
+    Optional<Process> findOneByProtocolsContains(Protocol protocol);
+
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -22,6 +22,12 @@ public class Protocol extends MetadataDocument {
         return linked;
     }
 
+    /* TODO
+    This method was originally made as simple as possible to only support the orphaned entity use case. However,
+    this can be enhanced further to add a full-fledged component that enables back linking to all Processes that refer
+    to this Protocol. In that case, the isLinked implementation will need to be changed to check if the list of
+    processes is empty or not. This approach was not initially chosen because it would have required data migration.
+     */
     public void useFor(Process process) {
         this.linked = true;
     }

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -28,7 +28,7 @@ public class Protocol extends MetadataDocument {
     to this Protocol. In that case, the isLinked implementation will need to be changed to check if the list of
     processes is empty or not. This approach was not initially chosen because it would have required data migration.
      */
-    public void useFor(Process process) {
+    public void markAsLinked() {
         this.linked = true;
     }
 

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -5,20 +5,25 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.humancellatlas.ingest.core.EntityType;
 import org.humancellatlas.ingest.core.MetadataDocument;
+import org.humancellatlas.ingest.process.Process;
 
-/**
- * Javadocs go here!
- *
- * @author Tony Burdett
- * @date 30/08/17
- */
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class Protocol extends MetadataDocument {
 
+    private boolean linked = false;
+
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
     public Protocol(Object content) {
         super(EntityType.PROTOCOL, content);
+    }
+
+    public boolean isLinked() {
+        return linked;
+    }
+
+    public void useFor(Process process) {
+        this.linked = true;
     }
 
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/ProtocolService.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/ProtocolService.java
@@ -9,7 +9,12 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+
+import java.util.Collections;
 
 /**
  * Javadocs go here!
@@ -21,6 +26,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Getter
 public class ProtocolService {
+
     private final @NonNull SubmissionEnvelopeRepository submissionEnvelopeRepository;
     private final @NonNull ProtocolRepository protocolRepository;
     private final @NonNull MetadataCrudService metadataCrudService;
@@ -39,6 +45,10 @@ public class ProtocolService {
         } else {
             return metadataUpdateService.acceptUpdate(protocol, submissionEnvelope);
         }
+    }
+
+    public Page<Protocol> retrieve(SubmissionEnvelope submission, Pageable pageable) {
+        return new PageImpl(Collections.emptyList());
     }
 
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/ProtocolService.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/ProtocolService.java
@@ -11,12 +11,8 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.Arrays;
-import java.util.Collections;
 
 /**
  * Javadocs go here!
@@ -54,7 +50,7 @@ public class ProtocolService {
     public Page<Protocol> retrieve(SubmissionEnvelope submission, Pageable pageable) {
         Page<Protocol> protocols = protocolRepository.findBySubmissionEnvelope(submission, pageable);
         protocols.forEach(protocol -> {
-            processRepository.findOneByProtocolsContains(protocol).ifPresent(protocol::useFor);
+            processRepository.findOneByProtocolsContains(protocol).ifPresent(it -> protocol.markAsLinked());
         });
         return protocols;
     }

--- a/src/main/java/org/humancellatlas/ingest/security/SecurityConfig.java
+++ b/src/main/java/org/humancellatlas/ingest/security/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(POST, "/submissionEnvelopes").authenticated()
                 .antMatchers(POST, "/projects").authenticated()
                 .antMatchers(GET, "/user/**").authenticated()
-                .antMatchers(GET, "/auth/account").authenticated()
+                .antMatchers(GET, "/auth/account/**").authenticated()
                 .antMatchers(POST, "/auth/registration").hasAuthority(GUEST.name())
                 .requestMatchers(SecurityConfig::isSecuredWranglerEndpointFromOutside).hasAnyAuthority(WRANGLER.name(), SERVICE.name())
                 .requestMatchers(SecurityConfig::isSecuredEndpointFromOutside).authenticated()

--- a/src/main/java/org/humancellatlas/ingest/security/SecurityConfig.java
+++ b/src/main/java/org/humancellatlas/ingest/security/SecurityConfig.java
@@ -87,7 +87,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .antMatchers(POST, "/submissionEnvelopes").authenticated()
                 .antMatchers(POST, "/projects").authenticated()
                 .antMatchers(GET, "/user/**").authenticated()
-                .antMatchers(GET, "/auth/account/**").authenticated()
+                .antMatchers(GET, "/auth/account").authenticated()
                 .antMatchers(POST, "/auth/registration").hasAuthority(GUEST.name())
                 .requestMatchers(SecurityConfig::isSecuredWranglerEndpointFromOutside).hasAnyAuthority(WRANGLER.name(), SERVICE.name())
                 .requestMatchers(SecurityConfig::isSecuredEndpointFromOutside).authenticated()

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
@@ -18,6 +18,7 @@ import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
+import org.humancellatlas.ingest.protocol.ProtocolService;
 import org.humancellatlas.ingest.state.SubmissionState;
 import org.humancellatlas.ingest.state.SubmitAction;
 import org.humancellatlas.ingest.state.ValidationState;
@@ -60,6 +61,7 @@ public class SubmissionController {
     private final @NonNull SubmissionEnvelopeService submissionEnvelopeService;
     private final @NonNull SubmissionStateMachineService submissionStateMachineService;
     private final @NonNull ProcessService processService;
+    private final @NonNull ProtocolService protocolService;
 
     private final @NonNull SubmissionEnvelopeRepository submissionEnvelopeRepository;
     private final @NonNull FileRepository fileRepository;
@@ -109,7 +111,7 @@ public class SubmissionController {
     ResponseEntity<?> getProtocols(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                    Pageable pageable,
                                    final PersistentEntityResourceAssembler resourceAssembler) {
-        Page<Protocol> protocols = getProtocolRepository().findBySubmissionEnvelope(submissionEnvelope, pageable);
+        Page<Protocol> protocols = protocolService.retrieve(submissionEnvelope, pageable);
         return ResponseEntity.ok(getPagedResourcesAssembler().toResource(protocols, resourceAssembler));
     }
 

--- a/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
@@ -1,0 +1,53 @@
+package org.humancellatlas.ingest.protocol;
+
+import org.humancellatlas.ingest.core.service.MetadataCrudService;
+import org.humancellatlas.ingest.core.service.MetadataUpdateService;
+import org.humancellatlas.ingest.submission.SubmissionEnvelope;
+import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+@SpringBootTest(classes=ProtocolService.class)
+public class ProtocolServiceTest {
+
+    @Autowired
+    private ProtocolService protocolService;
+
+    @MockBean
+    private MetadataCrudService metadataCrudService;
+
+    @MockBean
+    private MetadataUpdateService metadataUpdateService;
+
+    @MockBean
+    private ProtocolRepository protocolRepository;
+
+    @MockBean
+    private SubmissionEnvelopeRepository submissionEnvelopeRepository;
+
+    @Nested
+    class Submission {
+
+        @Test
+        void determineLinking() {
+            //given:
+            SubmissionEnvelope submission = new SubmissionEnvelope("89bcba7");
+
+            //when:
+            Page<Protocol> results = protocolService.retrieve(submission, mock(Pageable.class));
+
+            //then:
+            assertThat(results).isNotNull();
+        }
+
+    }
+
+}

--- a/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
@@ -53,22 +53,26 @@ public class ProtocolServiceTest {
             SubmissionEnvelope submission = new SubmissionEnvelope("89bcba7");
 
             //and:
-            Protocol protocol = new Protocol("test");
+            Protocol linked = new Protocol("linked");
+            Protocol notLinked = new Protocol("not linked");
             Pageable pageable = mock(Pageable.class);
-            doReturn(new PageImpl(asList(protocol))).when(protocolRepository)
+            doReturn(new PageImpl(asList(linked, notLinked))).when(protocolRepository)
                     .findBySubmissionEnvelope(submission, pageable);
 
             //and:
-            doReturn(Optional.of(new Process())).when(processRepository).findOneByProtocolsContains(protocol);
+            doReturn(Optional.of(new Process())).when(processRepository).findOneByProtocolsContains(linked);
+            doReturn(Optional.empty()).when(processRepository).findOneByProtocolsContains(notLinked);
 
             //when:
             Page<Protocol> results = protocolService.retrieve(submission, pageable);
 
             //then:
             assertThat(results).isNotNull();
-            assertThat(results.getTotalElements()).isEqualTo(1);
-            assertThat(results.getContent().get(0)).isEqualTo(protocol);
-            assertThat(protocol.isLinked()).isTrue();
+            assertThat(results.getTotalElements()).isEqualTo(2);
+
+            //and:
+            assertThat(linked.isLinked()).isTrue();
+            assertThat(notLinked.isLinked()).isFalse();
         }
 
     }

--- a/src/test/java/org/humancellatlas/ingest/security/web/AuthenticationControllerTest.java
+++ b/src/test/java/org/humancellatlas/ingest/security/web/AuthenticationControllerTest.java
@@ -207,7 +207,6 @@ public class AuthenticationControllerTest {
         }
 
         @Test
-        @Disabled
         //TODO this test was disabled because it was causing the Github CI script to fail for some reason.
         //The error can't be reproduced elsewhere.
         void unknownGuest() throws Exception {

--- a/src/test/java/org/humancellatlas/ingest/security/web/AuthenticationControllerTest.java
+++ b/src/test/java/org/humancellatlas/ingest/security/web/AuthenticationControllerTest.java
@@ -8,6 +8,7 @@ import org.humancellatlas.ingest.security.SecurityConfig;
 import org.humancellatlas.ingest.security.authn.oidc.OpenIdAuthentication;
 import org.humancellatlas.ingest.security.authn.oidc.UserInfo;
 import org.humancellatlas.ingest.security.exception.DuplicateAccount;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -206,6 +207,7 @@ public class AuthenticationControllerTest {
         }
 
         @Test
+        @Disabled
         void unknownGuest() throws Exception {
             //expect:
             webApp

--- a/src/test/java/org/humancellatlas/ingest/security/web/AuthenticationControllerTest.java
+++ b/src/test/java/org/humancellatlas/ingest/security/web/AuthenticationControllerTest.java
@@ -208,6 +208,8 @@ public class AuthenticationControllerTest {
 
         @Test
         @Disabled
+        //TODO this test was disabled because it was causing the Github CI script to fail for some reason.
+        //The error can't be reproduced elsewhere.
         void unknownGuest() throws Exception {
             //expect:
             webApp

--- a/src/test/java/org/humancellatlas/ingest/security/web/AuthenticationControllerTest.java
+++ b/src/test/java/org/humancellatlas/ingest/security/web/AuthenticationControllerTest.java
@@ -207,8 +207,6 @@ public class AuthenticationControllerTest {
         }
 
         @Test
-        //TODO this test was disabled because it was causing the Github CI script to fail for some reason.
-        //The error can't be reproduced elsewhere.
         void unknownGuest() throws Exception {
             //expect:
             webApp

--- a/src/test/java/org/humancellatlas/ingest/submission/web/SubmissionControllerTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/web/SubmissionControllerTest.java
@@ -8,6 +8,7 @@ import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.process.ProcessService;
 import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
+import org.humancellatlas.ingest.protocol.ProtocolService;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeService;
@@ -43,6 +44,8 @@ public class SubmissionControllerTest {
     private SubmissionEnvelopeService submissionEnvelopeService;
     @MockBean
     private ProcessService processService;
+    @MockBean
+    private ProtocolService protocolService;
 
     @MockBean
     private SubmissionEnvelopeRepository submissionEnvelopeRepository;


### PR DESCRIPTION
This first solution determines the linking in the code instead of joing records in the database. This is probably good for a first pass because the query is paginated and we can probably enforce some limits to how much record per page we can service. In the future we can explore other approaches.