### PR TITLE
Fixed query for finding one Process related to a Protocol

### DIFF
--- a/src/integration/java/org/humancellatlas/ingest/process/ProcessRepositoryTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/process/ProcessRepositoryTest.java
@@ -1,0 +1,61 @@
+package org.humancellatlas.ingest.process;
+
+import org.assertj.core.api.Assertions;
+import org.assertj.core.api.Assumptions;
+import org.humancellatlas.ingest.config.MigrationConfiguration;
+import org.humancellatlas.ingest.messaging.MessageRouter;
+import org.humancellatlas.ingest.protocol.Protocol;
+import org.humancellatlas.ingest.protocol.ProtocolRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@SpringBootTest
+public class ProcessRepositoryTest {
+
+    @Autowired
+    private ProcessRepository processRepository;
+
+    @Autowired
+    private ProtocolRepository protocolRepository;
+
+    @MockBean
+    private MigrationConfiguration migrationConfiguration;
+
+    @MockBean
+    private MessageRouter messageRouter;
+
+    @Test
+    public void findFirstByProtocolNonUnique() {
+        //given:
+        Protocol protocol = new Protocol("protocol");
+        protocol = protocolRepository.save(protocol);
+
+        //and:
+        Process process1 = new Process("process 1");
+        process1.addProtocol(protocol);
+        process1 = processRepository.save(process1);
+
+        //and:
+        Process process2 = new Process("process 2");
+        process2.addProtocol(protocol);
+        process2 = processRepository.save(process2);
+
+        //and:
+        assumeThat(processRepository.findAll()).hasSize(2);
+
+        //when:
+        Optional<Process> first = processRepository.findFirstByProtocolsContains(protocol);
+        assertThat(first.isPresent()).isTrue();
+        assertThat(first.get().getId()).isIn(asList(process1.getId(), process2.getId()));
+    }
+
+}

--- a/src/main/java/org/humancellatlas/ingest/process/Process.java
+++ b/src/main/java/org/humancellatlas/ingest/process/Process.java
@@ -51,8 +51,11 @@ public class Process extends MetadataDocument {
 
     public Process addInputBundleManifest(BundleManifest bundleManifest) {
         this.inputBundleManifests.add(bundleManifest);
-
         return this;
+    }
+
+    public void addProtocol(Protocol protocol) {
+        protocols.add(protocol);
     }
 
 }

--- a/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
@@ -55,6 +55,6 @@ public interface ProcessRepository extends MongoRepository<Process, String> {
     Stream<Process> findByInputBundleManifestsContains(BundleManifest bundleManifest);
 
     @RestResource(exported = false)
-    Optional<Process> findOneByProtocolsContains(Protocol protocol);
+    Optional<Process> findFirstByProtocolsContains(Protocol protocol);
 
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/ProtocolService.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/ProtocolService.java
@@ -50,7 +50,7 @@ public class ProtocolService {
     public Page<Protocol> retrieve(SubmissionEnvelope submission, Pageable pageable) {
         Page<Protocol> protocols = protocolRepository.findBySubmissionEnvelope(submission, pageable);
         protocols.forEach(protocol -> {
-            processRepository.findOneByProtocolsContains(protocol).ifPresent(it -> protocol.markAsLinked());
+            processRepository.findFirstByProtocolsContains(protocol).ifPresent(it -> protocol.markAsLinked());
         });
         return protocols;
     }

--- a/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
@@ -15,7 +15,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 
-import java.util.Arrays;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
@@ -60,8 +59,8 @@ public class ProtocolServiceTest {
                     .findBySubmissionEnvelope(submission, pageable);
 
             //and:
-            doReturn(Optional.of(new Process())).when(processRepository).findOneByProtocolsContains(linked);
-            doReturn(Optional.empty()).when(processRepository).findOneByProtocolsContains(notLinked);
+            doReturn(Optional.of(new Process())).when(processRepository).findFirstByProtocolsContains(linked);
+            doReturn(Optional.empty()).when(processRepository).findFirstByProtocolsContains(notLinked);
 
             //when:
             Page<Protocol> results = protocolService.retrieve(submission, pageable);


### PR DESCRIPTION
Replaced the find one query with find first as the former requires results to be unique.