### PR TITLE
Restrict PATCH and add new timestamp fields for tracking changes to metadata

### DIFF
--- a/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
@@ -7,6 +7,7 @@ import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.project.ProjectEventHandler;
 import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.schemas.SchemaService;
+import org.humancellatlas.ingest.state.ValidationState;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -140,12 +141,7 @@ class ProjectControllerTest {
             //and:
             project = repository.findById(project.getId()).get();
             assertThat((Map) project.getContent()).containsOnly(updatedDescription);
-
-            //and:
-            var projectCaptor = ArgumentCaptor.forClass(Project.class);
-            verify(projectEventHandler).editedProjectMetadata(projectCaptor.capture());
-            Project handledProject = projectCaptor.getValue();
-            assertThat(handledProject.getId()).isEqualTo(project.getId());
+            assertThat(project.getValidationState()).isEqualTo(ValidationState.DRAFT);
         }
 
     }

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/Biomaterial.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/Biomaterial.java
@@ -51,8 +51,8 @@ public class Biomaterial extends MetadataDocument {
     @DBRef(lazy = true)
     private Set<Process> derivedByProcesses = new HashSet<>();
 
-    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public Biomaterial(Object content) {
+    @JsonCreator
+    public Biomaterial(@JsonProperty("content") Object content) {
         super(EntityType.BIOMATERIAL, content);
     }
 

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
@@ -7,24 +7,18 @@ import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.biomaterial.BiomaterialService;
 import org.humancellatlas.ingest.core.Uuid;
-import org.humancellatlas.ingest.process.Process;
 import org.humancellatlas.ingest.process.ProcessRepository;
-import org.humancellatlas.ingest.project.Project;
-import org.humancellatlas.ingest.query.MetadataCriteria;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.PersistentEntityResource;
 import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
-import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -66,5 +60,18 @@ public class BiomaterialController {
     Biomaterial entity = getBiomaterialService().addBiomaterialToSubmissionEnvelope(submissionEnvelope, biomaterial);
     PersistentEntityResource resource = assembler.toFullResource(entity);
     return ResponseEntity.accepted().body(resource);
+  }
+
+  @RequestMapping(path = "/biomaterials/{id}", method = RequestMethod.PATCH)
+  HttpEntity<?> patchBiomaterial(@PathVariable("id") Biomaterial biomaterial,
+                                 @RequestBody Biomaterial biomaterialPatch,
+                                 PersistentEntityResourceAssembler assembler) {
+    if(biomaterialPatch.getContent() != null){
+      biomaterial.setContent(biomaterialPatch.getContent());
+    }
+
+    Biomaterial entity = biomaterialRepository.save(biomaterial);
+    PersistentEntityResource resource = assembler.toFullResource(entity);
+    return  ResponseEntity.accepted().body(resource);
   }
 }

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
@@ -1,5 +1,6 @@
 package org.humancellatlas.ingest.biomaterial.web;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -7,6 +8,8 @@ import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.biomaterial.BiomaterialService;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.file.File;
+import org.humancellatlas.ingest.patch.JsonPatcher;
 import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.PersistentEntityResource;
@@ -19,6 +22,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -38,6 +42,8 @@ public class BiomaterialController {
   private final @NonNull BiomaterialRepository biomaterialRepository;
 
   private final @NonNull PagedResourcesAssembler pagedResourcesAssembler;
+
+  private final @NonNull JsonPatcher jsonPatcher;
 
   @RequestMapping(path = "submissionEnvelopes/{sub_id}/biomaterials", method = RequestMethod.POST)
   ResponseEntity<Resource<?>> addBiomaterialToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
@@ -64,13 +70,13 @@ public class BiomaterialController {
 
   @RequestMapping(path = "/biomaterials/{id}", method = RequestMethod.PATCH)
   HttpEntity<?> patchBiomaterial(@PathVariable("id") Biomaterial biomaterial,
-                                 @RequestBody Biomaterial biomaterialPatch,
+                                 @RequestBody final ObjectNode patch,
                                  PersistentEntityResourceAssembler assembler) {
-    if(biomaterialPatch.getContent() != null){
-      biomaterial.setContent(biomaterialPatch.getContent());
-    }
+    List<String> allowedFields = List.of("content");
+    ObjectNode validPatch = patch.retain(allowedFields);
+    Biomaterial patchedBiomaterial = jsonPatcher.merge(validPatch, biomaterial);
 
-    Biomaterial entity = biomaterialRepository.save(biomaterial);
+    Biomaterial entity = biomaterialRepository.save(patchedBiomaterial);
     PersistentEntityResource resource = assembler.toFullResource(entity);
     return  ResponseEntity.accepted().body(resource);
   }

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
@@ -72,7 +72,7 @@ public class BiomaterialController {
   HttpEntity<?> patchBiomaterial(@PathVariable("id") Biomaterial biomaterial,
                                  @RequestBody final ObjectNode patch,
                                  PersistentEntityResourceAssembler assembler) {
-    List<String> allowedFields = List.of("content");
+    List<String> allowedFields = List.of("content", "validationErrors");
     ObjectNode validPatch = patch.retain(allowedFields);
     Biomaterial patchedBiomaterial = jsonPatcher.merge(validPatch, biomaterial);
 

--- a/src/main/java/org/humancellatlas/ingest/core/MetadataDocument.java
+++ b/src/main/java/org/humancellatlas/ingest/core/MetadataDocument.java
@@ -115,6 +115,7 @@ public abstract class MetadataDocument extends AbstractEntity {
         if (this.content == null || !this.content.equals(content)) {
             this.content = content;
             this.contentLastModified = Instant.now();
+            this.setDcpVersion(this.contentLastModified);
         }
     }
 

--- a/src/main/java/org/humancellatlas/ingest/core/MetadataDocument.java
+++ b/src/main/java/org/humancellatlas/ingest/core/MetadataDocument.java
@@ -22,26 +22,37 @@ import java.util.List;
  * @date 31/08/17
  */
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = "contentLastModified")
 public abstract class MetadataDocument extends AbstractEntity {
 
     @Setter
+    private Instant firstDcpVersion;
+
     private Instant dcpVersion;
 
-    @Setter
+    private Instant contentLastModified;
+
     private Object content;
 
-    // This property holds the reference to the submissionEnvelope this metadatadocument was part of.
-    // A metadatadocument is part of one submissionEnvelope.
-    // The other end of this relationship can be defined as a Set of metadataDocuments in SubmissionEnvelope.
+    // This property holds the reference to the submissionEnvelope this metadata document was part of.
+    // A metadata document is part of one submissionEnvelope.
+    // The other end of this relationship can be defined as a set of metadataDocuments in a submissionEnvelope.
     @Indexed
-    private @Setter @DBRef(lazy = true) SubmissionEnvelope submissionEnvelope;
+    @Setter
+    @DBRef(lazy = true)
+    private SubmissionEnvelope submissionEnvelope;
 
-    private @Setter Accession accession;
-    private @Setter ValidationState validationState;
-    private @Setter List<Object> validationErrors;
+    private @Setter
+    Accession accession;
 
-    private @Setter @Field
+    private @Setter
+    ValidationState validationState;
+
+    private @Setter
+    List<Object> validationErrors;
+
+    private @Setter
+    @Field
     Boolean isUpdate = false;
 
 
@@ -51,12 +62,14 @@ public abstract class MetadataDocument extends AbstractEntity {
         return log;
     }
 
-    protected MetadataDocument(){}
+    protected MetadataDocument() {
+    }
 
     protected MetadataDocument(EntityType type,
                                Object content) {
         super(type);
         this.content = content;
+        this.contentLastModified = Instant.now();
         this.validationState = ValidationState.DRAFT;
     }
 
@@ -95,8 +108,23 @@ public abstract class MetadataDocument extends AbstractEntity {
 
     public MetadataDocument enactStateTransition(ValidationState targetState) {
         this.validationState = targetState;
-
         return this;
     }
 
+    public void setContent(Object content) {
+        if (this.content == null || !this.content.equals(content)) {
+            this.content = content;
+            this.contentLastModified = Instant.now();
+        }
+    }
+
+    public void setDcpVersion(Instant dcpVersion) {
+        // DCP version should never be set to null
+        if (dcpVersion != null) {
+            if (this.dcpVersion == null) {
+                this.firstDcpVersion = dcpVersion;
+            }
+            this.dcpVersion = dcpVersion;
+        }
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/web/Links.java
+++ b/src/main/java/org/humancellatlas/ingest/core/web/Links.java
@@ -79,16 +79,14 @@ public class Links {
     public static final String PROJECTS_REL = "projects";
     public static final String PROTOCOLS_URL = "/protocols";
     public static final String PROTOCOLS_REL = "protocols";
-    public static final String ASSAYS_URL = "/assays";
-    public static final String ASSAYS_REL = "assays";
-    public static final String ANALYSES_URL = "/analyses";
-    public static final String ANALYSES_REL = "analyses";
     public static final String BUNDLE_MANIFESTS_URL = "/bundleManifests";
     public static final String BUNDLE_MANIFESTS_REL = "bundleManifests";
     public static final String SUBMISSION_MANIFEST_URL = "/submissionManifest";
     public static final String SUBMISSION_MANIFEST_REL = "submissionManifest";
     public static final String SUBMISSION_ERRORS_URL = "/submissionErrors";
     public static final String SUBMISSION_ERRORS_REL = "submissionEnvelopeErrors";
+    public static final String SUBMISSION_SUMMARY_URL = "/summary";
+    public static final String SUBMISSION_SUMMARY_REL = "summary";
     public static final String SUBMISSION_DOCUMENTS_SM_URL = "/documentSmReport";
     public static final String SUBMISSION_DOCUMENTS_SM_REL = "documentSmReport";
 
@@ -99,12 +97,6 @@ public class Links {
     public static final String FILE_REF_URL = "/fileReference";
     public static final String FILE_REF_REL = "inputFileReferences";
     public static final String FILE_REF_OLD_EVIL_REL = "add-file-reference";
-
-    // Links to Processes
-    public static final String INPUT_TO_PROCESSES_URL = "/inputToProcesses";
-    public static final String INPUT_TO_PROCESSES_REL = "inputToProcesses";
-    public static final String DERIVED_BY_PROCESSES_URL = "/derivedByProcesses";
-    public static final String DERIVED_BY_PROCESSES_REL = "derivedByProcesses";
 
     // Links from Processes
     public static final String INPUT_BIOMATERIALS_URL = "/inputBiomaterials";

--- a/src/main/java/org/humancellatlas/ingest/file/File.java
+++ b/src/main/java/org/humancellatlas/ingest/file/File.java
@@ -50,7 +50,10 @@ public class File extends MetadataDocument {
     @Indexed
     private String fileName;
     private String cloudUrl;
+
     private Checksums checksums;
+    private Checksums lastExportedChecksums;
+
     private ValidationJob validationJob;
     private UUID validationId;
     private UUID dataFileUuid;
@@ -63,8 +66,10 @@ public class File extends MetadataDocument {
     }
 
     @JsonCreator
-    public File(@JsonProperty("content") Object content) {
+    public File(@JsonProperty("content") Object content,
+                @JsonProperty("fileName") String fileName) {
         super(EntityType.FILE, content);
+        this.setFileName(fileName);
     }
 
     /**

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
@@ -83,7 +83,7 @@ public class FileController {
     HttpEntity<?> patchFile(@PathVariable("id") File file,
                             @RequestBody final ObjectNode patch,
                             PersistentEntityResourceAssembler assembler) {
-        List<String> allowedFields = List.of("content", "fileName");
+        List<String> allowedFields = List.of("content", "fileName", "validationJob", "validationErrors");
         ObjectNode validPatch = patch.retain(allowedFields);
         File patchedFile = jsonPatcher.merge(validPatch, file);
 

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
+import java.time.Instant;
+
 /**
  * Javadocs go here!
  *
@@ -70,4 +72,21 @@ public class FileController {
         return ResponseEntity.accepted().body(resource);
     }
 
+    @RequestMapping(path = "/files/{id}", method = RequestMethod.PATCH)
+    HttpEntity<?> patchBiomaterial(@PathVariable("id") File file,
+                                   @RequestBody File filePatch,
+                                   PersistentEntityResourceAssembler assembler) {
+
+        if(filePatch.getContent() != null){
+            file.setContent(filePatch.getContent());
+        }
+
+        if(filePatch.getFileName() != null){
+            file.setFileName(filePatch.getFileName());
+        }
+
+        File entity = fileRepository.save(file);
+        PersistentEntityResource resource = assembler.toFullResource(entity);
+        return  ResponseEntity.accepted().body(resource);
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
@@ -3,30 +3,22 @@ package org.humancellatlas.ingest.file.web;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
-import org.humancellatlas.ingest.biomaterial.Biomaterial;
-import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.file.*;
-import org.humancellatlas.ingest.process.Process;
 import org.humancellatlas.ingest.process.ProcessRepository;
-import org.humancellatlas.ingest.project.Project;
-import org.humancellatlas.ingest.query.MetadataCriteria;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.PersistentEntityResource;
 import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.MediaTypes;
-import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 /**
  * Javadocs go here!
@@ -53,46 +45,18 @@ public class FileController {
     @NonNull
     private final PagedResourcesAssembler pagedResourcesAssembler;
 
-    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/files/{filename:.+}",
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/files",
                                 method = RequestMethod.POST,
                                 produces = MediaTypes.HAL_JSON_VALUE)
     ResponseEntity<Resource<?>> createFile(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
-                                           @PathVariable("filename") String fileName,
                                            @RequestBody File file,
                                            final PersistentEntityResourceAssembler assembler) {
         try {
-            File createdFile = fileService.createFile(fileName, file, submissionEnvelope);
+            File createdFile = fileService.addFileToSubmissionEnvelope(submissionEnvelope, file);
             return ResponseEntity.accepted().body(assembler.toFullResource(createdFile));
         } catch (FileAlreadyExistsException e) {
             throw new IllegalStateException(e);
         }
-    }
-
-    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/files",
-                   method = RequestMethod.POST,
-                   produces = MediaTypes.HAL_JSON_VALUE)
-    ResponseEntity<Resource<?>> addFileToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
-                                                  @RequestBody File file,
-                                                  @RequestParam("updatingUuid") Optional<UUID> updatingUuid,
-                                                  final PersistentEntityResourceAssembler assembler) {
-        updatingUuid.ifPresent(uuid -> {
-            file.setUuid(new Uuid(uuid.toString()));
-            file.setIsUpdate(true);
-        });
-        File entity = getFileService().addFileToSubmissionEnvelope(submissionEnvelope, file);
-        PersistentEntityResource resource = assembler.toFullResource(entity);
-        return ResponseEntity.accepted().body(resource);
-    }
-
-    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/files/{id}",
-            method = RequestMethod.PUT,
-            produces = MediaTypes.HAL_JSON_VALUE)
-    ResponseEntity<Resource<?>> linkFileToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
-                                                   @PathVariable("id") File file,
-                                                   final PersistentEntityResourceAssembler assembler) {
-        File entity = getFileService().addFileToSubmissionEnvelope(submissionEnvelope, file);
-        PersistentEntityResource resource = assembler.toFullResource(entity);
-        return ResponseEntity.accepted().body(resource);
     }
 
     @RequestMapping(path = "/files/{id}/validationJob",
@@ -105,4 +69,5 @@ public class FileController {
         PersistentEntityResource resource = assembler.toFullResource(entity);
         return ResponseEntity.accepted().body(resource);
     }
+
 }

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileListener.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileListener.java
@@ -59,7 +59,7 @@ public class FileListener {
                                                .findByUuidUuid(envelopeUuid));
         if(envelopeForMessage.isPresent()){
             try {
-                fileService.createFile(fileMessage.getFileName(), new File(), envelopeForMessage.get());
+                fileService.addFileToSubmissionEnvelope(envelopeForMessage.get(), new File(null, fileMessage.getFileName()));
             } catch (FileAlreadyExistsException e) {
                 log.info(String.format("File listener attempted to create a File resource with name %s but it already existed for envelope %s",
                                        fileMessage.getFileName(),

--- a/src/main/java/org/humancellatlas/ingest/process/Process.java
+++ b/src/main/java/org/humancellatlas/ingest/process/Process.java
@@ -1,6 +1,7 @@
 package org.humancellatlas.ingest.process;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -50,8 +51,8 @@ public class Process extends MetadataDocument {
     public Process() {
     }
 
-    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public Process(Object content) {
+    @JsonCreator
+    public Process(@JsonProperty("content") Object content) {
         super(EntityType.PROCESS, content);
     }
 

--- a/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
+++ b/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
@@ -7,10 +7,8 @@ import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.core.web.Links;
 import org.humancellatlas.ingest.file.File;
-import org.humancellatlas.ingest.process.*;
 import org.humancellatlas.ingest.process.Process;
-import org.humancellatlas.ingest.protocol.Protocol;
-import org.humancellatlas.ingest.query.MetadataCriteria;
+import org.humancellatlas.ingest.process.*;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -19,13 +17,13 @@ import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
-import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -154,6 +152,20 @@ public class ProcessController {
                                                      final PersistentEntityResourceAssembler resourceAssembler) {
         Page<Process> processes = processService.findProcessesByInputBundleUuid(UUID.fromString(bundleUuid), pageable);
         return ResponseEntity.ok(pagedResourcesAssembler.toResource(processes, resourceAssembler));
+    }
+
+    @RequestMapping(path = "/processes/{id}", method = RequestMethod.PATCH)
+    HttpEntity<?> patchBiomaterial(@PathVariable("id") Process process,
+                                   @RequestBody Process processPatch,
+                                   PersistentEntityResourceAssembler assembler) {
+        if(processPatch.getContent() != null){
+            process.setContent(processPatch.getContent());
+        }
+
+
+        Process entity = processRepository.save(process);
+        PersistentEntityResource resource = assembler.toFullResource(entity);
+        return  ResponseEntity.accepted().body(resource);
     }
 }
 

--- a/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
+++ b/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
@@ -163,7 +163,7 @@ public class ProcessController {
     HttpEntity<?> patchProcess(@PathVariable("id") Process process,
                                @RequestBody final ObjectNode patch,
                                PersistentEntityResourceAssembler assembler) {
-        List<String> allowedFields = List.of("content");
+        List<String> allowedFields = List.of("content", "validationErrors");
         ObjectNode validPatch = patch.retain(allowedFields);
         Process patchedProcess = jsonPatcher.merge(validPatch, process);
 

--- a/src/main/java/org/humancellatlas/ingest/project/Project.java
+++ b/src/main/java/org/humancellatlas/ingest/project/Project.java
@@ -53,6 +53,7 @@ public class Project extends MetadataDocument {
     @Setter
     private Object identifyingOrganisms;
 
+    @Setter
     private String primaryWrangler;
 
 

--- a/src/main/java/org/humancellatlas/ingest/project/Project.java
+++ b/src/main/java/org/humancellatlas/ingest/project/Project.java
@@ -2,6 +2,7 @@ package org.humancellatlas.ingest.project;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -55,8 +56,8 @@ public class Project extends MetadataDocument {
     private String primaryWrangler;
 
 
-    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public Project(Object content) {
+    @JsonCreator
+    public Project(@JsonProperty("content") Object content) {
         super(EntityType.PROJECT, content);
     }
 

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -82,7 +82,7 @@ public class ProjectController {
                                        @RequestParam(value = "partial", defaultValue = "false") Boolean partial,
                                        @RequestBody final ObjectNode patch, final PersistentEntityResourceAssembler assembler) {
 
-        List<String> allowedFields = List.of("content", "releaseDate", "primaryWrangler", "accessionDate", "technology", "dataAccess", "identifyingOrganisms");
+        List<String> allowedFields = List.of("content", "releaseDate", "primaryWrangler", "accessionDate", "technology", "dataAccess", "identifyingOrganisms", "validationErrors");
         ObjectNode validPatch = patch.retain(allowedFields);
         Project patchedProject = jsonPatcher.merge(validPatch, project);
         patchedProject = projectRepository.save(patchedProject);

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -21,7 +21,6 @@ import org.humancellatlas.ingest.project.ProjectService;
 import org.humancellatlas.ingest.project.exception.NonEmptyProject;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
-import org.humancellatlas.ingest.query.MetadataCriteria;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,13 +34,16 @@ import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
 import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
-import java.util.*;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
 
 /**
  * Javadocs go here!
@@ -177,6 +179,44 @@ public class ProjectController {
             Map<String, String> errorResponse = Map.of("message", message);
             return ResponseEntity.status(HttpStatus.CONFLICT).body(errorResponse);
         }
+    }
+
+    @RequestMapping(path = "/projects/{id}", method = RequestMethod.PATCH)
+    HttpEntity<?> patchBiomaterial(@PathVariable("id") Project project,
+                                   @RequestBody Project projectPatch,
+                                   PersistentEntityResourceAssembler assembler) {
+
+        if(projectPatch.getContent() != null){
+            project.setContent(projectPatch.getContent());
+        }
+
+        if(projectPatch.getReleaseDate() != null){
+            project.setReleaseDate(projectPatch.getReleaseDate());
+        }
+
+        if(projectPatch.getPrimaryWrangler() != null){
+            project.setPrimaryWrangler(projectPatch.getPrimaryWrangler());
+        }
+
+        if(projectPatch.getAccessionDate() != null){
+            project.setAccessionDate(projectPatch.getAccessionDate());
+        }
+
+        if(projectPatch.getTechnology() != null){
+            project.setTechnology(projectPatch.getTechnology());
+        }
+
+        if(projectPatch.getDataAccess() != null){
+            project.setDataAccess(projectPatch.getDataAccess());
+        }
+
+        if(projectPatch.getIdentifyingOrganisms() != null){
+            project.setIdentifyingOrganisms(projectPatch.getIdentifyingOrganisms());
+        }
+
+        Project entity = projectRepository.save(project);
+        PersistentEntityResource resource = assembler.toFullResource(entity);
+        return  ResponseEntity.accepted().body(resource);
     }
 
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -1,6 +1,7 @@
 package org.humancellatlas.ingest.protocol;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,8 +22,8 @@ public class Protocol extends MetadataDocument {
 
     private boolean linked = false;
 
-    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
-    public Protocol(Object content) {
+    @JsonCreator
+    public Protocol(@JsonProperty("content") Object content) {
         super(EntityType.PROTOCOL, content);
     }
 

--- a/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
@@ -7,21 +7,18 @@ import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
 import org.humancellatlas.ingest.protocol.ProtocolService;
-import org.humancellatlas.ingest.query.MetadataCriteria;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.rest.webmvc.PersistentEntityResource;
 import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
 import org.springframework.data.web.PagedResourcesAssembler;
 import org.springframework.hateoas.ExposesResourceFor;
-import org.springframework.hateoas.PagedResources;
 import org.springframework.hateoas.Resource;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+import java.time.Instant;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -62,5 +59,18 @@ public class ProtocolController {
         Protocol entity = getProtocolService().addProtocolToSubmissionEnvelope(submissionEnvelope, protocol);
         PersistentEntityResource resource = assembler.toFullResource(entity);
         return ResponseEntity.accepted().body(resource);
+    }
+
+    @RequestMapping(path = "/protocols/{id}", method = RequestMethod.PATCH)
+    HttpEntity<?> patchBiomaterial(@PathVariable("id") Protocol protocol,
+                                   @RequestBody Protocol protocolPatch,
+                                   PersistentEntityResourceAssembler assembler) {
+        if(protocolPatch.getContent() != null){
+            protocol.setContent(protocolPatch.getContent());
+        }
+
+        Protocol entity = protocolRepository.save(protocol);
+        PersistentEntityResource resource = assembler.toFullResource(entity);
+        return  ResponseEntity.accepted().body(resource);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
@@ -1,9 +1,12 @@
 package org.humancellatlas.ingest.protocol.web;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.patch.JsonPatcher;
+import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
 import org.humancellatlas.ingest.protocol.ProtocolService;
@@ -19,6 +22,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -38,6 +42,8 @@ public class ProtocolController {
 
     private final @NonNull PagedResourcesAssembler pagedResourcesAssembler;
 
+    private final @NonNull JsonPatcher jsonPatcher;
+
     @RequestMapping(path = "/submissionEnvelopes/{sub_id}/protocols", method = RequestMethod.POST)
     ResponseEntity<Resource<?>> addProtocolToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                                       @RequestBody Protocol protocol,
@@ -55,22 +61,22 @@ public class ProtocolController {
     @RequestMapping(path = "/submissionEnvelopes/{sub_id}/protocols/{protocol_id}", method = RequestMethod.PUT)
     ResponseEntity<Resource<?>> linkProtocolToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                                        @PathVariable("id") Protocol protocol,
-                                                      PersistentEntityResourceAssembler assembler) {
+                                                       PersistentEntityResourceAssembler assembler) {
         Protocol entity = getProtocolService().addProtocolToSubmissionEnvelope(submissionEnvelope, protocol);
         PersistentEntityResource resource = assembler.toFullResource(entity);
         return ResponseEntity.accepted().body(resource);
     }
 
     @RequestMapping(path = "/protocols/{id}", method = RequestMethod.PATCH)
-    HttpEntity<?> patchBiomaterial(@PathVariable("id") Protocol protocol,
-                                   @RequestBody Protocol protocolPatch,
-                                   PersistentEntityResourceAssembler assembler) {
-        if(protocolPatch.getContent() != null){
-            protocol.setContent(protocolPatch.getContent());
-        }
+    HttpEntity<?> patchProtocol(@PathVariable("id") Protocol protocol,
+                                @RequestBody final ObjectNode patch,
+                                PersistentEntityResourceAssembler assembler) {
+        List<String> allowedFields = List.of("content");
+        ObjectNode validPatch = patch.retain(allowedFields);
+        Protocol patchedProtocol = jsonPatcher.merge(validPatch, protocol);
 
-        Protocol entity = protocolRepository.save(protocol);
+        Protocol entity = protocolRepository.save(patchedProtocol);
         PersistentEntityResource resource = assembler.toFullResource(entity);
-        return  ResponseEntity.accepted().body(resource);
+        return ResponseEntity.accepted().body(resource);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
@@ -71,7 +71,7 @@ public class ProtocolController {
     HttpEntity<?> patchProtocol(@PathVariable("id") Protocol protocol,
                                 @RequestBody final ObjectNode patch,
                                 PersistentEntityResourceAssembler assembler) {
-        List<String> allowedFields = List.of("content");
+        List<String> allowedFields = List.of("content", "validationErrors");
         ObjectNode validPatch = patch.retain(allowedFields);
         Protocol patchedProtocol = jsonPatcher.merge(validPatch, protocol);
 

--- a/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
+++ b/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
@@ -43,6 +43,10 @@ public class MetadataStateChangeListener extends AbstractMongoEventListener<Meta
     public void onBeforeConvert(BeforeConvertEvent<MetadataDocument> event) {
         MetadataDocument document = event.getSource();
 
+        if (!Optional.ofNullable(document.getDcpVersion()).isPresent()) {
+            document.setDcpVersion(document.getSubmissionDate());
+        }
+
         if (!Optional.ofNullable(document.getUuid()).isPresent()) {
             document.setUuid(Uuid.newUuid());
         }

--- a/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
+++ b/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
@@ -43,10 +43,6 @@ public class MetadataStateChangeListener extends AbstractMongoEventListener<Meta
     public void onBeforeConvert(BeforeConvertEvent<MetadataDocument> event) {
         MetadataDocument document = event.getSource();
 
-        if (!Optional.ofNullable(document.getDcpVersion()).isPresent()) {
-            document.setDcpVersion(document.getSubmissionDate());
-        }
-
         if (!Optional.ofNullable(document.getUuid()).isPresent()) {
             document.setUuid(Uuid.newUuid());
         }

--- a/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
+++ b/src/main/java/org/humancellatlas/ingest/state/MetadataStateChangeListener.java
@@ -43,6 +43,8 @@ public class MetadataStateChangeListener extends AbstractMongoEventListener<Meta
     public void onBeforeConvert(BeforeConvertEvent<MetadataDocument> event) {
         MetadataDocument document = event.getSource();
 
+//      TODO Ideally, this should be being set when the submission is submitted.
+//      The exporter could set this. Putting this back here for now for convenience.
         if (!Optional.ofNullable(document.getDcpVersion()).isPresent()) {
             document.setDcpVersion(document.getSubmissionDate());
         }

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionEnvelopeResourceProcessor.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionEnvelopeResourceProcessor.java
@@ -58,18 +58,6 @@ public class SubmissionEnvelopeResourceProcessor implements ResourceProcessor<Re
                 .withRel(Links.PROTOCOLS_REL);
     }
 
-    private Link getAssaysLink(SubmissionEnvelope submissionEnvelope) {
-        return entityLinks.linkForSingleResource(submissionEnvelope)
-                .slash(Links.ASSAYS_URL)
-                .withRel(Links.ASSAYS_REL);
-    }
-
-    private Link getAnalysesLink(SubmissionEnvelope submissionEnvelope) {
-        return entityLinks.linkForSingleResource(submissionEnvelope)
-                          .slash(Links.ANALYSES_URL)
-                          .withRel(Links.ANALYSES_REL);
-    }
-
     private Link getBundleManifestsLink(SubmissionEnvelope submissionEnvelope) {
         return entityLinks.linkForSingleResource(submissionEnvelope)
                           .slash(Links.BUNDLE_MANIFESTS_URL)
@@ -92,6 +80,12 @@ public class SubmissionEnvelopeResourceProcessor implements ResourceProcessor<Re
         return entityLinks.linkForSingleResource(submissionEnvelope)
                 .slash(Links.SUBMISSION_ERRORS_URL)
                 .withRel(Links.SUBMISSION_ERRORS_REL);
+    }
+
+    private Link getSubmissionSummary(SubmissionEnvelope submissionEnvelope) {
+        return entityLinks.linkForSingleResource(submissionEnvelope)
+                .slash(Links.SUBMISSION_SUMMARY_URL)
+                .withRel(Links.SUBMISSION_SUMMARY_REL);
     }
 
     private Link getSubmissionDocumentStateLink(SubmissionEnvelope submissionEnvelope) {
@@ -256,13 +250,12 @@ public class SubmissionEnvelopeResourceProcessor implements ResourceProcessor<Re
         resource.add(getFilesLink(submissionEnvelope));
         resource.add(getProjectsLink(submissionEnvelope));
         resource.add(getProtocolsLink(submissionEnvelope));
-        resource.add(getAssaysLink(submissionEnvelope));
-        resource.add(getAnalysesLink(submissionEnvelope));
         resource.add(getBundleManifestsLink(submissionEnvelope));
         resource.add(getSubmissionManifestsLink(submissionEnvelope));
         resource.add(getExportJobsLink(submissionEnvelope));
         resource.add(getSubmissionErrorsLink(submissionEnvelope));
         resource.add(getSubmissionDocumentStateLink(submissionEnvelope));
+        resource.add(getSubmissionSummary(submissionEnvelope));
 
 
         // add subresource links for allowed state transition requests

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionSummaryController.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionSummaryController.java
@@ -23,8 +23,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @RestController
-@RequestMapping("/submissionEnvelopes")
-public class SubmissionSummaryController implements ResourceProcessor<RepositoryLinksResource> {
+public class SubmissionSummaryController {
 
     @Autowired
     BiomaterialRepository biomaterialRepository;
@@ -35,13 +34,8 @@ public class SubmissionSummaryController implements ResourceProcessor<Repository
     @Autowired
     ProtocolRepository protocolRepository;
 
-    @Override
-    public RepositoryLinksResource process(RepositoryLinksResource resource) {
-        resource.add(ControllerLinkBuilder.linkTo(SubmissionSummaryController.class).withRel("submissionEnvelopes"));
-        return resource;
-    }
 
-    @RequestMapping(path = "/{sub_id}/summary", method = RequestMethod.GET)
+    @RequestMapping(path = "/submissionEnvelopes/{sub_id}/summary", method = RequestMethod.GET)
     @ResponseBody
     public SubmissionSummary submissionSummary(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope) {
 

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
@@ -83,7 +83,7 @@ public class ProjectServiceTest {
             submissionSet1.forEach(submission ->  project1.addToSubmissionEnvelopes(submission));
 
             //and:
-            var project2 = new Project(null);
+            var project2 = new Project("project2");
             BeanUtils.copyProperties(project1, project2);
             var submissionSet2 = IntStream.range(10, 15)
                     .mapToObj(Integer::toString)
@@ -116,7 +116,7 @@ public class ProjectServiceTest {
             submissionSet1.forEach(project1::addToSubmissionEnvelopes);
 
             //and:
-            var project2 = new Project("Project2");
+            var project2 = new Project("project2");
             BeanUtils.copyProperties(project1, project2);
             var submissionSet2 = IntStream.range(10, 15)
                 .mapToObj(Integer::toString)
@@ -210,11 +210,11 @@ public class ProjectServiceTest {
             var project = new Project("test project");
 
             //and: copy of project with no submissions
-            var persistentEmptyProject = new Project(null);
+            var persistentEmptyProject = new Project("project");
             BeanUtils.copyProperties(project, persistentEmptyProject);
 
             //and: copy of project with submissions
-            var persistentNonEmptyProject = new Project(null);
+            var persistentNonEmptyProject = new Project("project");
             BeanUtils.copyProperties(project, persistentNonEmptyProject);
             IntStream.range(0, 3)
                     .mapToObj(Integer::toString).map(SubmissionEnvelope::new)

--- a/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
@@ -125,7 +125,7 @@ public class SubmissionEnvelopeServiceTest {
 
         //given metadata outside the SubmissionEnvelope
         Biomaterial testOutsideBiomaterial = new Biomaterial(Map.ofEntries(Map.entry("key", UUID.randomUUID())));
-        File testOutsideFile = new File(Map.ofEntries(Map.entry("key", UUID.randomUUID())));
+        File testOutsideFile = new File(Map.ofEntries(Map.entry("key", UUID.randomUUID())), "");
         Process testOutsideProcess = new Process(Map.ofEntries(Map.entry("key", UUID.randomUUID())));
 
         //given links to metadata outside of the SubmissionEnvelope


### PR DESCRIPTION
user story task ticket: ebi-ait/dcp-ingest-central#109

Changes:

- Ingest Core API index page is returning multiple submission envelopes links.  This is causing the big submission integration test to fail. 

```
  "submissionEnvelopes": [
      {
        "href": "https://api.ingest.dev.archive.data.humancellatlas.org/submissionEnvelopes{?page,size,sort}",
        "templated": true,
        "title": "Access or create new submission envelopes"
      },
      {
        "href": "https://api.ingest.dev.archive.data.humancellatlas.org/submissionEnvelopes",
        "title": "Access or create new submission envelopes"
      }
    ],

```

- Make create metadata payload consistent , payload should always have content attribute

All entity endpoints POST `submission/<id>/<entity-type>` will now accept payloads with format `{"content": {}}`. This should now be consistent with POST `submission/<id>/files` endpoint which also accepts filename in the payload `{"content": {}, "fileName": <filename>}`. The POST `submission/<id>/files/<filename>` endpoint with filename was also removed. 

There are no external users of Ingest API yet so this shouldn't break anything. The ingest integration tests and ingest-client may be using this and would need to be adjusted.

- Clean up file create methods
- Remove unused endpoints
- Any updates to document would 
    - set it back to Draft
    - update contentLastModified 
    - and should retrigger validation
