### PR TITLE
Stop project returning to draft state if content unchanged

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
@@ -8,8 +8,7 @@ import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.biomaterial.BiomaterialService;
 import org.humancellatlas.ingest.core.Uuid;
-import org.humancellatlas.ingest.file.File;
-import org.humancellatlas.ingest.patch.JsonPatcher;
+import org.humancellatlas.ingest.core.service.MetadataUpdateService;
 import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.PersistentEntityResource;
@@ -35,49 +34,47 @@ import java.util.UUID;
 @Getter
 public class BiomaterialController {
 
-  private final @NonNull ProcessRepository processRepository;
+    private final @NonNull ProcessRepository processRepository;
 
-  private final @NonNull BiomaterialService biomaterialService;
+    private final @NonNull BiomaterialService biomaterialService;
 
-  private final @NonNull BiomaterialRepository biomaterialRepository;
+    private final @NonNull BiomaterialRepository biomaterialRepository;
 
-  private final @NonNull PagedResourcesAssembler pagedResourcesAssembler;
+    private final @NonNull PagedResourcesAssembler pagedResourcesAssembler;
 
-  private final @NonNull JsonPatcher jsonPatcher;
+    private final @NonNull MetadataUpdateService metadataUpdateService;
 
-  @RequestMapping(path = "submissionEnvelopes/{sub_id}/biomaterials", method = RequestMethod.POST)
-  ResponseEntity<Resource<?>> addBiomaterialToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
-                                                       @RequestBody Biomaterial biomaterial,
-                                                       @RequestParam("updatingUuid") Optional<UUID> updatingUuid,
-                                                       PersistentEntityResourceAssembler assembler) {
-    updatingUuid.ifPresent(uuid -> {
-      biomaterial.setUuid(new Uuid(uuid.toString()));
-      biomaterial.setIsUpdate(true);
-    });
-    Biomaterial entity = getBiomaterialService().addBiomaterialToSubmissionEnvelope(submissionEnvelope, biomaterial);
-    PersistentEntityResource resource = assembler.toFullResource(entity);
-    return ResponseEntity.accepted().body(resource);
-  }
+    @RequestMapping(path = "submissionEnvelopes/{sub_id}/biomaterials", method = RequestMethod.POST)
+    ResponseEntity<Resource<?>> addBiomaterialToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
+                                                         @RequestBody Biomaterial biomaterial,
+                                                         @RequestParam("updatingUuid") Optional<UUID> updatingUuid,
+                                                         PersistentEntityResourceAssembler assembler) {
+        updatingUuid.ifPresent(uuid -> {
+            biomaterial.setUuid(new Uuid(uuid.toString()));
+            biomaterial.setIsUpdate(true);
+        });
+        Biomaterial entity = getBiomaterialService().addBiomaterialToSubmissionEnvelope(submissionEnvelope, biomaterial);
+        PersistentEntityResource resource = assembler.toFullResource(entity);
+        return ResponseEntity.accepted().body(resource);
+    }
 
-  @RequestMapping(path = "submissionEnvelopes/{sub_id}/biomaterials/{id}", method = RequestMethod.PUT)
-  ResponseEntity<Resource<?>> linkBiomaterialToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
-      @PathVariable("id") Biomaterial biomaterial,
-      PersistentEntityResourceAssembler assembler) {
-    Biomaterial entity = getBiomaterialService().addBiomaterialToSubmissionEnvelope(submissionEnvelope, biomaterial);
-    PersistentEntityResource resource = assembler.toFullResource(entity);
-    return ResponseEntity.accepted().body(resource);
-  }
+    @RequestMapping(path = "submissionEnvelopes/{sub_id}/biomaterials/{id}", method = RequestMethod.PUT)
+    ResponseEntity<Resource<?>> linkBiomaterialToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
+                                                          @PathVariable("id") Biomaterial biomaterial,
+                                                          PersistentEntityResourceAssembler assembler) {
+        Biomaterial entity = getBiomaterialService().addBiomaterialToSubmissionEnvelope(submissionEnvelope, biomaterial);
+        PersistentEntityResource resource = assembler.toFullResource(entity);
+        return ResponseEntity.accepted().body(resource);
+    }
 
-  @RequestMapping(path = "/biomaterials/{id}", method = RequestMethod.PATCH)
-  HttpEntity<?> patchBiomaterial(@PathVariable("id") Biomaterial biomaterial,
-                                 @RequestBody final ObjectNode patch,
-                                 PersistentEntityResourceAssembler assembler) {
-    List<String> allowedFields = List.of("content", "validationErrors");
-    ObjectNode validPatch = patch.retain(allowedFields);
-    Biomaterial patchedBiomaterial = jsonPatcher.merge(validPatch, biomaterial);
-
-    Biomaterial entity = biomaterialRepository.save(patchedBiomaterial);
-    PersistentEntityResource resource = assembler.toFullResource(entity);
-    return  ResponseEntity.accepted().body(resource);
-  }
+    @PatchMapping(path = "/biomaterials/{id}")
+    HttpEntity<?> patchBiomaterial(@PathVariable("id") Biomaterial biomaterial,
+                                   @RequestBody final ObjectNode patch,
+                                   PersistentEntityResourceAssembler assembler) {
+        List<String> allowedFields = List.of("content", "validationErrors");
+        ObjectNode validPatch = patch.retain(allowedFields);
+        Biomaterial updatedBiomaterial = metadataUpdateService.update(biomaterial, validPatch);
+        PersistentEntityResource resource = assembler.toFullResource(updatedBiomaterial);
+        return ResponseEntity.accepted().body(resource);
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/MetadataUpdateService.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/MetadataUpdateService.java
@@ -1,11 +1,17 @@
 package org.humancellatlas.ingest.core.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import org.humancellatlas.ingest.core.EntityType;
 import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.exception.RedundantUpdateException;
+import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
+import org.humancellatlas.ingest.patch.JsonPatcher;
 import org.humancellatlas.ingest.patch.PatchService;
+import org.humancellatlas.ingest.project.Project;
+import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.stereotype.Service;
 
@@ -18,18 +24,37 @@ public class MetadataUpdateService {
     private final @NonNull MetadataCrudService metadataCrudService;
     private final @NonNull PatchService patchService;
 
+    private final @NonNull ValidationStateChangeService validationStateChangeService;
+    private final @NonNull JsonPatcher jsonPatcher;
+
+    public <T extends MetadataDocument> T update(T metadataDocument, ObjectNode patch) {
+        ObjectMapper mapper = new ObjectMapper();
+
+        Boolean contentChanged = patch.get("content") != null &&
+                !patch.get("content").equals(mapper.valueToTree(metadataDocument).get("content"));
+
+        T patchedMetadata = jsonPatcher.merge(patch, metadataDocument);
+        T doc = metadataCrudService.save(patchedMetadata);
+
+        if (contentChanged) {
+            validationStateChangeService.changeValidationState(doc.getType(), doc.getId(), ValidationState.DRAFT);
+        }
+
+        return doc;
+    }
+
     public <T extends MetadataDocument> T acceptUpdate(T updateDocument, SubmissionEnvelope submissionEnvelope) {
         T originalDocument = metadataCrudService.findOriginalByUuid(updateDocument.getUuid().getUuid().toString(), updateDocument.getType());
 
-        if(metadataDifferService.anyDifference(originalDocument, updateDocument)) {
+        if (metadataDifferService.anyDifference(originalDocument, updateDocument)) {
             T savedUpdateDocument = metadataCrudService.addToSubmissionEnvelopeAndSave(updateDocument, submissionEnvelope);
             patchService.storePatch(originalDocument, savedUpdateDocument, submissionEnvelope);
             return savedUpdateDocument;
         } else {
             throw new RedundantUpdateException(String.format("Attempted to update %s document at %s with contents of %s but there is no diff",
-                                                             updateDocument.getType(),
-                                                             originalDocument.getId(),
-                                                             updateDocument.getId()));
+                    updateDocument.getType(),
+                    originalDocument.getId(),
+                    updateDocument.getId()));
         }
     }
 
@@ -57,4 +82,5 @@ public class MetadataUpdateService {
         canonicalDocument.setContent(updateDocument.getContent());
         return canonicalDocument;
     }
+
 }

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -82,7 +82,7 @@ public class ProjectController {
                                        @RequestParam(value = "partial", defaultValue = "false") Boolean partial,
                                        @RequestBody final ObjectNode patch, final PersistentEntityResourceAssembler assembler) {
 
-        List<String> allowedFields = List.of("content", "releaseDate", "primaryWrangler", "accessionDate", "technology", "dataAccess", "identifyingOrganisms", "validationErrors");
+        List<String> allowedFields = List.of("content", "releaseDate", "primaryWrangler", "accessionDate", "technology", "organ", "dataAccess", "identifyingOrganisms", "validationErrors");
         ObjectNode validPatch = patch.retain(allowedFields);
         Project patchedProject = jsonPatcher.merge(validPatch, project);
         patchedProject = projectRepository.save(patchedProject);

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -92,11 +92,11 @@ public class ProjectController {
         ObjectNode validPatch = patch.retain(allowedFields);
 
         ObjectMapper mapper = new ObjectMapper();
-        Boolean contentChanged = validPatch.get("content").equals(mapper.valueToTree(project).get("content"));
+        Boolean contentChanged = !validPatch.get("content").equals(mapper.valueToTree(project).get("content"));
 
         Project patchedProject = jsonPatcher.merge(validPatch, project);
         patchedProject = projectRepository.save(patchedProject);
-        if(!contentChanged) {
+        if(contentChanged) {
             validationStateChangeService.changeValidationState(EntityType.PROJECT, project.getId(), ValidationState.DRAFT);
         }
         if (!partial) {

--- a/src/test/java/org/humancellatlas/ingest/core/service/MetadataUpdateServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/MetadataUpdateServiceTest.java
@@ -1,0 +1,151 @@
+package org.humancellatlas.ingest.core.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.humancellatlas.ingest.patch.JsonPatcher;
+import org.humancellatlas.ingest.patch.PatchService;
+import org.humancellatlas.ingest.project.Project;
+import org.humancellatlas.ingest.state.ValidationState;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {MetadataUpdateService.class})
+public class MetadataUpdateServiceTest {
+    @Autowired
+    private MetadataUpdateService service;
+
+    @MockBean
+    private MetadataDifferService metadataDifferService;
+
+    @MockBean
+    private MetadataCrudService metadataCrudService;
+
+    @MockBean
+    private JsonPatcher jsonPatcher;
+
+    @MockBean
+    private PatchService patchService;
+
+
+    @MockBean
+    private ValidationStateChangeService validationStateChangeService;
+
+    @Test
+    public void testUpdateShouldSaveAndReturnUpdatedMetadata() {
+        //given:
+        ObjectMapper mapper = new ObjectMapper();
+
+        ObjectNode content = mapper.createObjectNode();
+        ObjectNode projectCore0 = content.putObject("project_core");
+        projectCore0.put("project_title", "Old Project Title");
+
+        Project project = new Project(content);
+
+        ObjectNode patch = mapper.createObjectNode();
+        ObjectNode newContent = patch.putObject("content");
+        ObjectNode projectCore = newContent.putObject("project_core");
+        projectCore.put("project_title", "New Project Title");
+
+        when(metadataCrudService.save(any())).thenReturn(project);
+        when(jsonPatcher.merge(any(ObjectNode.class), any())).thenReturn(project);
+
+        //when:
+        Project updatedProject = service.update(project, patch);
+
+        //then:
+        assertThat(updatedProject).isEqualTo(project);
+        verify(metadataCrudService).save(project);
+    }
+
+    @Test
+    public void testUpdateShouldSetStateToDraftWhenContentChanged() {
+        //given:
+        ObjectMapper mapper = new ObjectMapper();
+
+        ObjectNode content = mapper.createObjectNode();
+        ObjectNode projectCore0 = content.putObject("project_core");
+        projectCore0.put("project_title", "Old Project Title");
+
+        Project project = new Project(content);
+
+        ObjectNode patch = mapper.createObjectNode();
+        ObjectNode newContent = patch.putObject("content");
+        ObjectNode projectCore = newContent.putObject("project_core");
+        projectCore.put("project_title", "New Project Title");
+
+        when(metadataCrudService.save(any())).thenReturn(project);
+        when(jsonPatcher.merge(any(ObjectNode.class), any())).thenReturn(project);
+
+        //when:
+        Project updatedProject = service.update(project, patch);
+
+        //then:
+        assertThat(updatedProject).isEqualTo(project);
+        verify(metadataCrudService).save(project);
+        verify(validationStateChangeService).changeValidationState(project.getType(), project.getId(), ValidationState.DRAFT);
+    }
+
+    @Test
+    public void testUpdateShouldNotSetStateWhenContentIsUnchanged() {
+        //given:
+        ObjectMapper mapper = new ObjectMapper();
+
+        ObjectNode content = mapper.createObjectNode();
+        ObjectNode projectCore0 = content.putObject("project_core");
+        projectCore0.put("project_title", "Old Project Title");
+
+        Project project = new Project(content);
+
+        ObjectNode patch = mapper.createObjectNode();
+        ObjectNode newContent = patch.putObject("content");
+        ObjectNode projectCore = newContent.putObject("project_core");
+        projectCore.put("project_title", "Old Project Title");
+
+        when(metadataCrudService.save(any())).thenReturn(project);
+        when(jsonPatcher.merge(any(ObjectNode.class), any())).thenReturn(project);
+
+        //when:
+        Project updatedProject = service.update(project, patch);
+
+        //then:
+        assertThat(updatedProject).isEqualTo(project);
+        verify(metadataCrudService).save(project);
+        verify(validationStateChangeService, never()).changeValidationState(project.getType(), project.getId(), ValidationState.DRAFT);
+    }
+
+    @Test
+    public void testUpdateShouldNotSetStateWhenNoContent() {
+        //given:
+        ObjectMapper mapper = new ObjectMapper();
+
+        ObjectNode content = mapper.createObjectNode();
+        ObjectNode projectCore0 = content.putObject("project_core");
+        projectCore0.put("project_title", "Old Project Title");
+
+        Project project = new Project(content);
+
+        ObjectNode patch = mapper.createObjectNode();
+        patch.put("releaseDate", "2021-02-03T04:35:39.641Z");
+
+        when(metadataCrudService.save(any())).thenReturn(project);
+        when(jsonPatcher.merge(any(ObjectNode.class), any())).thenReturn(project);
+
+        //when:
+        Project updatedProject = service.update(project, patch);
+
+        //then:
+        assertThat(updatedProject).isEqualTo(project);
+        verify(metadataCrudService).save(project);
+        verify(validationStateChangeService, never()).changeValidationState(project.getType(), project.getId(), ValidationState.DRAFT);
+    }
+}


### PR DESCRIPTION
Relates to [this PR in UI](https://github.com/ebi-ait/ingest-ui/pull/79) and [this task](https://app.zenhub.com/workspaces/dcp-ingest-product-development-5f71ca62a3cb47326bdc1b5c/issues/ebi-ait/dcp-ingest-central/154).

I think this is the right way to do it but not 100%. I tested on local but will be better to test on dev with a few projects that are in non-draft state.