### PR TITLE
Project Catalogue Endpoint

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
@@ -67,4 +67,7 @@ public interface ProjectRepository extends MongoRepository<Project, String> {
     @RestResource(exported = false)
     Stream<Project> findByUuid(Uuid uuid);
 
+    @RestResource(rel = "catalogue", path = "catalogue")
+    Page<Project> findByPublishedToCatalogueTrue(Pageable pageable);
+
 }

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -83,7 +83,7 @@ public class ProjectController {
                                        @RequestParam(value = "partial", defaultValue = "false") Boolean partial,
                                        @RequestBody final ObjectNode patch, final PersistentEntityResourceAssembler assembler) {
 
-        List<String> allowedFields = List.of("content", "releaseDate", "primaryWrangler", "accessionDate", "technology", "organ", "dataAccess", "identifyingOrganisms", "validationErrors");
+        List<String> allowedFields = List.of("content", "releaseDate", "primaryWrangler", "accessionDate", "technology", "organ", "dataAccess", "identifyingOrganisms", "validationErrors", "publishedToCatalogue", "publicationsInfo");
         ObjectNode validPatch = patch.retain(allowedFields);
 
         Project updatedProject = metadataUpdateService.update(project, validPatch);


### PR DESCRIPTION
Subtask of [#284](https://github.com/ebi-ait/dcp-ingest-central/issues/284)
Adds a new Endpoint `/projects/search/catalogue` that delivers all projects where the **PublishedToCatalogue** flag is **True**.
Accepts the standard pageable attributes so a full list could be returned with 
`/projects/search/catalogue?page=0&size=2000`

Also fixes an issue patching Project Catalogue & Publications Info from PR #65
