### PR TITLE
Adding back the serializer class because to correctly return Published to DCP state

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/project/WranglingState.java
+++ b/src/main/java/org/humancellatlas/ingest/project/WranglingState.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 
-
+@JsonSerialize(using = WranglingStateSerializer.class)
 public enum WranglingState {
     NEW("New"),
     ELIGIBLE("Eligible"),

--- a/src/main/java/org/humancellatlas/ingest/project/WranglingStateSerializer.java
+++ b/src/main/java/org/humancellatlas/ingest/project/WranglingStateSerializer.java
@@ -1,0 +1,15 @@
+package org.humancellatlas.ingest.project;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.humancellatlas.ingest.project.WranglingState;
+
+import java.io.IOException;
+
+public class WranglingStateSerializer extends JsonSerializer<WranglingState> {
+    @Override
+    public void serialize(WranglingState value, JsonGenerator generator, SerializerProvider serializers) throws IOException {
+        generator.writeString(value.text);
+    }
+}

--- a/src/test/java/org/humancellatlas/ingest/project/WranglingStateTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/WranglingStateTest.java
@@ -1,4 +1,4 @@
-package org.humancellatlas.ingest.project.wranglingpriority;
+package org.humancellatlas.ingest.project;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#317

The enum PUBLISHED_IN_DCP is being returned as “Published in dcp” instead of “Published in DCP”.
I had to put back the serializer to force this behaviour.
Using the annotation JsonValue alone won’t work, it’s passing in unit tests but somehow the enum value in the response is different,

value in Mongo DB:
```
"wranglingState" : "PUBLISHED_IN_DCP
```