### PR TITLE
Allow for filtering projects by more fields

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
+++ b/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
@@ -1,0 +1,19 @@
+package org.humancellatlas.ingest.project;
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.humancellatlas.ingest.archiving.entity.ArchiveEntityTypeSerializer;
+
+@JsonSerialize(using = ArchiveEntityTypeSerializer.class)
+public enum DataAccessTypes {
+    OPEN("All fully open"),
+    MANAGED("All managed access"),
+    MIXTURE("A mixture of open and managed"),
+    COMPLICATED("It's complicated"),
+    SEQUENCING_RUN("sequencingRun");
+
+    protected String type;
+
+    DataAccessTypes(String type) {
+        this.type = type;
+    }
+}

--- a/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
+++ b/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
@@ -9,7 +9,7 @@ public enum DataAccessTypes {
     OPEN("All fully open"),
     MANAGED("All managed access"),
     MIXTURE("A mixture of open and managed"),
-    COMPLICATED("It's complicated")
+    COMPLICATED("It's complicated");
 
     @Getter
     final String label;

--- a/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
+++ b/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
@@ -10,7 +10,6 @@ public enum DataAccessTypes {
     MANAGED("All managed access"),
     MIXTURE("A mixture of open and managed"),
     COMPLICATED("It's complicated"),
-    SEQUENCING_RUN("sequencingRun");
 
     @Getter
     final String label;

--- a/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
+++ b/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
@@ -9,7 +9,7 @@ public enum DataAccessTypes {
     OPEN("All fully open"),
     MANAGED("All managed access"),
     MIXTURE("A mixture of open and managed"),
-    COMPLICATED("It's complicated"),
+    COMPLICATED("It's complicated")
 
     @Getter
     final String label;

--- a/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
+++ b/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
@@ -1,10 +1,7 @@
 package org.humancellatlas.ingest.project;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import lombok.Getter;
-import org.humancellatlas.ingest.archiving.entity.ArchiveEntityTypeSerializer;
 
-@JsonSerialize(using = ArchiveEntityTypeSerializer.class)
 public enum DataAccessTypes {
     OPEN("All fully open"),
     MANAGED("All managed access"),

--- a/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
+++ b/src/main/java/org/humancellatlas/ingest/project/DataAccessTypes.java
@@ -1,6 +1,7 @@
 package org.humancellatlas.ingest.project;
 
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import lombok.Getter;
 import org.humancellatlas.ingest.archiving.entity.ArchiveEntityTypeSerializer;
 
 @JsonSerialize(using = ArchiveEntityTypeSerializer.class)
@@ -11,9 +12,10 @@ public enum DataAccessTypes {
     COMPLICATED("It's complicated"),
     SEQUENCING_RUN("sequencingRun");
 
-    protected String type;
+    @Getter
+    final String label;
 
-    DataAccessTypes(String type) {
-        this.type = type;
+    DataAccessTypes(String label) {
+        this.label = label;
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
@@ -7,6 +7,7 @@ import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.TextCriteria;
 
+import javax.swing.text.html.Option;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -23,14 +24,17 @@ public class ProjectQueryBuilder {
         addLTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMaxCellCount());
         addGTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMinCellCount());
         addInCriterionForAttribute(criteriaList, "identifyingOrganisms", searchFilter.getIdentifyingOrganism());
-        addIsCriterionForAttribute(criteriaList, "organ", searchFilter.getOrgan());
 
         Optional.ofNullable(searchFilter.getHasOfficialHcaPublication())
                 .map(value ->
                         Criteria.where("content.publications")
                                 .elemMatch(Criteria.where("official_hca_publication").is(value))
-                )
-                .ifPresent(criteriaList::add);
+                ).ifPresent(criteriaList::add);
+
+        Optional.ofNullable(searchFilter.getOrganOntology())
+                .map(value ->
+                        Criteria.where("organ.ontologies").elemMatch(Criteria.where("ontology").is(value))
+                ).ifPresent(criteriaList::add);
 
         Criteria queryCriteria = new Criteria().andOperator(criteriaList.toArray(new Criteria[criteriaList.size()]));
         Query query = new Query().addCriteria(queryCriteria);

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
@@ -18,7 +18,7 @@ public class ProjectQueryBuilder {
         List<Criteria> criteriaList = new ArrayList<>();
         criteriaList.add(Criteria.where("isUpdate").is(false));
         addCriterionForAttribute(criteriaList, "wranglingState", searchFilter.getWranglingState());
-        addCriterionForAttribute(criteriaList, "primaryWrangler", searchFilter.getWrangler());
+        addCriterionForAttribute(criteriaList, "primaryWrangler", searchFilter.getPrimaryWrangler());
 
         Criteria queryCriteria = new Criteria().andOperator(criteriaList.toArray(new Criteria[criteriaList.size()]));
         Query query = new Query().addCriteria(queryCriteria);

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
@@ -17,8 +17,20 @@ public class ProjectQueryBuilder {
     public static Query buildProjectsQuery(SearchFilter searchFilter) {
         List<Criteria> criteriaList = new ArrayList<>();
         criteriaList.add(Criteria.where("isUpdate").is(false));
-        addCriterionForAttribute(criteriaList, "wranglingState", searchFilter.getWranglingState());
-        addCriterionForAttribute(criteriaList, "primaryWrangler", searchFilter.getPrimaryWrangler());
+        addIsCriterionForAttribute(criteriaList, "wranglingState", searchFilter.getWranglingState());
+        addIsCriterionForAttribute(criteriaList, "primaryWrangler", searchFilter.getPrimaryWrangler());
+        addIsCriterionForAttribute(criteriaList, "wranglingPriority", searchFilter.getPriority());
+        addLTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMaxCellCount());
+        addGTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMinCellCount());
+        addInCriterionForAttribute(criteriaList, "identifyingOrganisms", searchFilter.getSpecies());
+        addIsCriterionForAttribute(criteriaList, "organ", searchFilter.getOrgan());
+
+        Optional.ofNullable(searchFilter.getHcaPublication())
+                .map(value ->
+                        Criteria.where("content.publications")
+                                .elemMatch(Criteria.where("official_hca_publication").is(value))
+                )
+                .ifPresent(criteriaList::add);
 
         Criteria queryCriteria = new Criteria().andOperator(criteriaList.toArray(new Criteria[criteriaList.size()]));
         Query query = new Query().addCriteria(queryCriteria);
@@ -48,11 +60,35 @@ public class ProjectQueryBuilder {
                 .map(uuid -> Criteria.where("uuid.uuid").is(uuid));
     }
 
-    private static void addCriterionForAttribute(List<Criteria> criteria_list,
-                                                 String attributreName,
-                                                 String attributeValue) {
+    private static void addIsCriterionForAttribute(List<Criteria> criteria_list,
+                                                   String attributeName,
+                                                   Object attributeValue) {
         Optional.ofNullable(attributeValue)
-                .map(value -> Criteria.where(attributreName).is(value))
+                .map(value -> Criteria.where(attributeName).is(value))
+                .ifPresent(criteria_list::add);
+    }
+
+    private static void addLTECriterionForAttribute(List<Criteria> criteria_list,
+                                                       String attributeName,
+                                                       Integer attributeValue) {
+        Optional.ofNullable(attributeValue)
+                .map(value -> Criteria.where(attributeName).lte(value))
+                .ifPresent(criteria_list::add);
+    }
+
+    private static void addGTECriterionForAttribute(List<Criteria> criteria_list,
+                                                    String attributeName,
+                                                    Integer attributeValue) {
+        Optional.ofNullable(attributeValue)
+                .map(value -> Criteria.where(attributeName).gte(value))
+                .ifPresent(criteria_list::add);
+    }
+
+    private static void addInCriterionForAttribute(List<Criteria> criteria_list,
+                                                    String attributeName,
+                                                    Object attributeValue) {
+        Optional.ofNullable(attributeValue)
+                .map(value -> Criteria.where(attributeName).in(value))
                 .ifPresent(criteria_list::add);
     }
 

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
@@ -23,7 +23,10 @@ public class ProjectQueryBuilder {
         addLTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMaxCellCount());
         addGTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMinCellCount());
         addInCriterionForAttribute(criteriaList, "identifyingOrganisms", searchFilter.getIdentifyingOrganism());
-        addIsCriterionForAttribute(criteriaList, "dataAccess.type", searchFilter.getDataAccess());
+
+        if(searchFilter.getDataAccess() != null){
+            addIsCriterionForAttribute(criteriaList, "dataAccess.type", searchFilter.getDataAccess().getLabel());
+        }
 
         Optional.ofNullable(searchFilter.getHasOfficialHcaPublication())
                 .map(value ->

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
@@ -19,13 +19,13 @@ public class ProjectQueryBuilder {
         criteriaList.add(Criteria.where("isUpdate").is(false));
         addIsCriterionForAttribute(criteriaList, "wranglingState", searchFilter.getWranglingState());
         addIsCriterionForAttribute(criteriaList, "primaryWrangler", searchFilter.getPrimaryWrangler());
-        addIsCriterionForAttribute(criteriaList, "wranglingPriority", searchFilter.getPriority());
+        addIsCriterionForAttribute(criteriaList, "wranglingPriority", searchFilter.getWranglingPriority());
         addLTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMaxCellCount());
         addGTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMinCellCount());
-        addInCriterionForAttribute(criteriaList, "identifyingOrganisms", searchFilter.getSpecies());
+        addInCriterionForAttribute(criteriaList, "identifyingOrganisms", searchFilter.getIdentifyingOrganism());
         addIsCriterionForAttribute(criteriaList, "organ", searchFilter.getOrgan());
 
-        Optional.ofNullable(searchFilter.getHcaPublication())
+        Optional.ofNullable(searchFilter.getHasOfficialHcaPublication())
                 .map(value ->
                         Criteria.where("content.publications")
                                 .elemMatch(Criteria.where("official_hca_publication").is(value))

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
@@ -23,6 +23,7 @@ public class ProjectQueryBuilder {
         addLTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMaxCellCount());
         addGTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMinCellCount());
         addInCriterionForAttribute(criteriaList, "identifyingOrganisms", searchFilter.getIdentifyingOrganism());
+        addIsCriterionForAttribute(criteriaList, "dataAccess.type", searchFilter.getDataAccess());
 
         Optional.ofNullable(searchFilter.getHasOfficialHcaPublication())
                 .map(value ->

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
@@ -7,7 +7,6 @@ import org.springframework.data.mongodb.core.query.CriteriaDefinition;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.TextCriteria;
 
-import javax.swing.text.html.Option;
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;

--- a/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
@@ -12,7 +12,15 @@ public class SearchFilter {
     @Getter String search;
     @Getter String wranglingState;
     @Getter String primaryWrangler;
+    @Getter Integer priority;
+    @Getter Boolean hcaPublication;
+    @Getter String species;
+    @Getter String organ;
 
     @Builder.Default
     @Getter SearchType searchType = SearchType.AllKeywords;
+    @Builder.Default
+    @Getter Integer minCellCount = 0;
+    @Builder.Default
+    @Getter Integer maxCellCount = Integer.MAX_VALUE;
 }

--- a/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
@@ -19,7 +19,7 @@ public class SearchFilter {
     @Getter String organOntology;
     @Getter Integer minCellCount;
     @Getter Integer maxCellCount;
-    @Getter String dataAccess;
+    @Getter DataAccessTypes dataAccess;
 
     @Builder.Default
     @Getter SearchType searchType = SearchType.AllKeywords;

--- a/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
@@ -12,9 +12,9 @@ public class SearchFilter {
     @Getter String search;
     @Getter String wranglingState;
     @Getter String primaryWrangler;
-    @Getter Integer priority;
-    @Getter Boolean hcaPublication;
-    @Getter String species;
+    @Getter Integer wranglingPriority;
+    @Getter Boolean hasOfficialHcaPublication;
+    @Getter String identifyingOrganism;
     @Getter String organ;
 
     @Builder.Default

--- a/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
@@ -11,7 +11,7 @@ import lombok.ToString;
 public class SearchFilter {
     @Getter String search;
     @Getter String wranglingState;
-    @Getter String wrangler;
+    @Getter String primaryWrangler;
 
     @Builder.Default
     @Getter SearchType searchType = SearchType.AllKeywords;

--- a/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
@@ -16,11 +16,9 @@ public class SearchFilter {
     @Getter Boolean hasOfficialHcaPublication;
     @Getter String identifyingOrganism;
     @Getter String organOntology;
+    @Getter Integer minCellCount;
+    @Getter Integer maxCellCount;
 
     @Builder.Default
     @Getter SearchType searchType = SearchType.AllKeywords;
-    @Builder.Default
-    @Getter Integer minCellCount = 0;
-    @Builder.Default
-    @Getter Integer maxCellCount = Integer.MAX_VALUE;
 }

--- a/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
@@ -19,8 +19,7 @@ public class SearchFilter {
     @Getter String organOntology;
     @Getter Integer minCellCount;
     @Getter Integer maxCellCount;
-    @Getter
-    DataAccessTypes dataAccess;
+    @Getter String dataAccess;
 
     @Builder.Default
     @Getter SearchType searchType = SearchType.AllKeywords;

--- a/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
+import org.humancellatlas.ingest.project.DataAccessTypes;
 
 @AllArgsConstructor
 @Builder
@@ -18,6 +19,8 @@ public class SearchFilter {
     @Getter String organOntology;
     @Getter Integer minCellCount;
     @Getter Integer maxCellCount;
+    @Getter
+    DataAccessTypes dataAccess;
 
     @Builder.Default
     @Getter SearchType searchType = SearchType.AllKeywords;

--- a/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/SearchFilter.java
@@ -15,7 +15,7 @@ public class SearchFilter {
     @Getter Integer wranglingPriority;
     @Getter Boolean hasOfficialHcaPublication;
     @Getter String identifyingOrganism;
-    @Getter String organ;
+    @Getter String organOntology;
 
     @Builder.Default
     @Getter SearchType searchType = SearchType.AllKeywords;

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterQueryBuilderTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterQueryBuilderTest.java
@@ -12,19 +12,21 @@ import java.util.Optional;
 public class ProjectFilterQueryBuilderTest {
     @Test
     void null_search_type_with_non_null_text() {
-        SearchFilter searchFilter = new SearchFilter(
-                "project keyword",
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null,
-                null
-        );
+        SearchFilter searchFilter = SearchFilter.builder()
+                .search("project keyword")
+                .wranglingState(null)
+                .primaryWrangler(null)
+                .wranglingPriority(null)
+                .hasOfficialHcaPublication(null)
+                .identifyingOrganism(null)
+                .organOntology(null)
+                .minCellCount(null)
+                .maxCellCount(null)
+                .dataAccess(null)
+                .searchType(null)
+                .build();
+
+
         ProjectQueryBuilder.buildProjectsQuery(searchFilter);
         // no exception thrown when searchType is null
     }

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterQueryBuilderTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterQueryBuilderTest.java
@@ -22,6 +22,7 @@ public class ProjectFilterQueryBuilderTest {
                 null,
                 null,
                 null,
+                null,
                 null
         );
         ProjectQueryBuilder.buildProjectsQuery(searchFilter);

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterQueryBuilderTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterQueryBuilderTest.java
@@ -12,7 +12,18 @@ import java.util.Optional;
 public class ProjectFilterQueryBuilderTest {
     @Test
     void null_search_type_with_non_null_text() {
-        SearchFilter searchFilter = new SearchFilter("project keyword", null, null, null);
+        SearchFilter searchFilter = new SearchFilter(
+                "project keyword",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null
+        );
         ProjectQueryBuilder.buildProjectsQuery(searchFilter);
         // no exception thrown when searchType is null
     }

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -251,6 +251,27 @@ class ProjectFilterTest {
     }
 
     @Test
+    void filter_by_data_access() {
+        //given
+        Project project4 = makeProject("project4");
+        project4.setDataAccess(Map.of("type", DataAccessTypes.OPEN.toString()));
+        this.mongoTemplate.save(project4);
+        //when
+        SearchFilter searchFilter = SearchFilter.builder().dataAccess(DataAccessTypes.OPEN).build();
+
+        Pageable pageable = PageRequest.of(0, 10);
+        Page<Project> result = projectService.filterProjects(searchFilter, pageable);
+
+        // then
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent())
+                .hasSize(1)
+                .usingComparatorForElementFieldsWithType(upToMillies, Instant.class)
+                .usingRecursiveFieldByFieldElementComparator()
+                .containsExactly(project4);
+    }
+
+    @Test
     void filter_by_text() {
         // given
         //when
@@ -380,6 +401,7 @@ class ProjectFilterTest {
                 "AN_ONTOLOGY_TERM",
                 0,
                 10000,
+                DataAccessTypes.MANAGED,
                 SearchType.AllKeywords
         );
     }

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -122,7 +122,7 @@ class ProjectFilterTest {
     void filter_by_wrangler() {
         // given
         //when
-        SearchFilter searchFilter = SearchFilter.builder().wrangler(this.project2.getPrimaryWrangler()).build();
+        SearchFilter searchFilter = SearchFilter.builder().primaryWrangler(this.project2.getPrimaryWrangler()).build();
 
         Pageable pageable = PageRequest.of(0, 10);
         Page<Project> result = projectService.filterProjects(searchFilter, pageable);
@@ -258,7 +258,18 @@ class ProjectFilterTest {
 
     @Test
     void all_args_constructor() {
-        new SearchFilter("a", "b", "c", SearchType.AllKeywords);
+        new SearchFilter(
+                "a",
+                "b",
+                "c",
+                1,
+                false,
+                "Human",
+                "AN_ONTOLOGY_TERM",
+                SearchType.AllKeywords,
+                0,
+                10000
+        );
     }
 
     private static Project makeProject(String title) {
@@ -269,6 +280,7 @@ class ProjectFilterTest {
         project.setPrimaryWrangler("wrangler_" + title);
         project.setWranglingState(WranglingState.NEW);
         project.setUuid(Uuid.newUuid());
+        project.setCellCount(100);
         return project;
     }
 

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -188,11 +188,12 @@ class ProjectFilterTest {
     void filter_by_identifying_organisms() {
         //given
         Project project4 = makeProject("project4");
-        project4.setIdentifyingOrganisms(List.of("Human"));
+        String human = "Human";
+        project4.setIdentifyingOrganisms(List.of(human));
         this.mongoTemplate.save(project4);
 
         //when
-        SearchFilter searchFilter = SearchFilter.builder().identifyingOrganism("Human").build();
+        SearchFilter searchFilter = SearchFilter.builder().identifyingOrganism(human).build();
 
         Pageable pageable = PageRequest.of(0, 10);
         Page<Project> result = projectService.filterProjects(searchFilter, pageable);
@@ -210,10 +211,11 @@ class ProjectFilterTest {
     void filter_by_organ_ontology() {
         //given
         Project project4 = makeProject("project4");
-        project4.setOrgan(Map.of("ontologies", List.of(Map.of("ontology", "AN_ONTOLOGY"))));
+        String ontologyTerm = "AN_ONTOLOGY";
+        project4.setOrgan(Map.of("ontologies", List.of(Map.of("ontology", ontologyTerm))));
         this.mongoTemplate.save(project4);
         //when
-        SearchFilter searchFilter = SearchFilter.builder().organOntology("AN_ONTOLOGY").build();
+        SearchFilter searchFilter = SearchFilter.builder().organOntology(ontologyTerm).build();
 
         Pageable pageable = PageRequest.of(0, 10);
         Page<Project> result = projectService.filterProjects(searchFilter, pageable);

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -378,9 +378,9 @@ class ProjectFilterTest {
                 false,
                 "Human",
                 "AN_ONTOLOGY_TERM",
-                SearchType.AllKeywords,
                 0,
-                10000
+                10000,
+                SearchType.AllKeywords
         );
     }
 

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -254,7 +254,7 @@ class ProjectFilterTest {
     void filter_by_data_access() {
         //given
         Project project4 = makeProject("project4");
-        project4.setDataAccess(Map.of("type", DataAccessTypes.OPEN.toString()));
+        project4.setDataAccess(Map.of("type", DataAccessTypes.OPEN.getLabel()));
         this.mongoTemplate.save(project4);
         //when
         SearchFilter searchFilter = SearchFilter.builder().dataAccess(DataAccessTypes.OPEN).build();


### PR DESCRIPTION
dcp-426

- Adds hasOfficialHcaPublication, identifyingOrganism, organOntology, minCellCount, and maxCellCount to the SearchFilter class
- Adds corresponding logic in ProjectQueryBuilder

Work to move cell count fields to the new `estimated_cell_count` field in the schema to be done in another PR