### PR TITLE
Use content.estimated_cell_count

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectQueryBuilder.java
@@ -21,8 +21,8 @@ public class ProjectQueryBuilder {
         addIsCriterionForAttribute(criteriaList, "wranglingState", searchFilter.getWranglingState());
         addIsCriterionForAttribute(criteriaList, "primaryWrangler", searchFilter.getPrimaryWrangler());
         addIsCriterionForAttribute(criteriaList, "wranglingPriority", searchFilter.getWranglingPriority());
-        addLTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMaxCellCount());
-        addGTECriterionForAttribute(criteriaList, "cellCount", searchFilter.getMinCellCount());
+        addLTECriterionForAttribute(criteriaList, "content.estimated_cell_count", searchFilter.getMaxCellCount());
+        addGTECriterionForAttribute(criteriaList, "content.estimated_cell_count", searchFilter.getMinCellCount());
         addInCriterionForAttribute(criteriaList, "identifyingOrganisms", searchFilter.getIdentifyingOrganism());
 
         Optional.ofNullable(searchFilter.getHasOfficialHcaPublication())

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -233,21 +233,22 @@ class ProjectFilterTest {
     void filter_by_cell_count() {
         //given
         Project project4 = makeProject("project4");
-        project4.setCellCount(1000);
+        Integer cellCount = 1000;
+        project4.setContent(Map.of("estimated_cell_count", cellCount));
         this.mongoTemplate.save(project4);
         //when
-        SearchFilter searchFilter = SearchFilter.builder().maxCellCount(project1.getCellCount()).minCellCount(0).build();
+        SearchFilter searchFilter = SearchFilter.builder().maxCellCount(cellCount).minCellCount(cellCount).build();
 
         Pageable pageable = PageRequest.of(0, 10);
         Page<Project> result = projectService.filterProjects(searchFilter, pageable);
 
         // then
-        assertThat(result.getTotalElements()).isEqualTo(3);
+        assertThat(result.getTotalElements()).isEqualTo(1);
         assertThat(result.getContent())
-                .hasSize(3)
+                .hasSize(1)
                 .usingComparatorForElementFieldsWithType(upToMillies, Instant.class)
                 .usingRecursiveFieldByFieldElementComparator()
-                .containsExactlyInAnyOrder(project1, project2, project3);
+                .containsExactly(project4);
     }
 
     @Test
@@ -392,7 +393,6 @@ class ProjectFilterTest {
         project.setPrimaryWrangler("wrangler_" + title);
         project.setWranglingState(WranglingState.NEW);
         project.setUuid(Uuid.newUuid());
-        project.setCellCount(100);
         project.setWranglingPriority(1);
         return project;
     }


### PR DESCRIPTION
dcp-426

Uses `content.estimated_cell_count` instead of `project.cellCount` for filtering

To be merged after migration in dcp-445