### PR TITLE
Add a new requested state

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/state/SubmissionGraphValidationState.java
+++ b/src/main/java/org/humancellatlas/ingest/state/SubmissionGraphValidationState.java
@@ -2,6 +2,7 @@ package org.humancellatlas.ingest.state;
 
 public enum SubmissionGraphValidationState {
     PENDING,
+    REQUESTED,
     VALIDATING,
     VALID,
     INVALID

--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
@@ -111,8 +111,11 @@ public class SubmissionEnvelope extends AbstractEntity {
         List<SubmissionGraphValidationState> allowedStates = new ArrayList<>();
         switch (fromState) {
             case PENDING:
-                allowedStates.add(SubmissionGraphValidationState.VALIDATING);
+                allowedStates.add(SubmissionGraphValidationState.REQUESTED);
                 break;
+            case REQUESTED:
+                allowedStates.add(SubmissionGraphValidationState.PENDING);
+                allowedStates.add(SubmissionGraphValidationState.VALIDATING);
             case VALIDATING:
                 allowedStates.add(SubmissionGraphValidationState.PENDING);
                 allowedStates.add(SubmissionGraphValidationState.VALID);
@@ -121,7 +124,7 @@ public class SubmissionEnvelope extends AbstractEntity {
             case VALID:
             case INVALID:
                 allowedStates.add(SubmissionGraphValidationState.PENDING);
-                allowedStates.add(SubmissionGraphValidationState.VALIDATING);
+                allowedStates.add(SubmissionGraphValidationState.REQUESTED);
                 break;
             default:
                 break;

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
@@ -350,8 +350,9 @@ public class SubmissionController {
     @RequestMapping(path = "/submissionEnvelopes/{id}/validateGraph", method = RequestMethod.POST)
     HttpEntity<?> requestGraphValidation(@PathVariable("id") SubmissionEnvelope submissionEnvelope,
                                          final PersistentEntityResourceAssembler resourceAssembler) {
+        HttpEntity<?> response = this.performGraphRequest(SubmissionGraphValidationState.REQUESTED, submissionEnvelope, resourceAssembler);
         messageRouter.routeGraphValidationMessageFor(submissionEnvelope);
-        return ResponseEntity.accepted().body(resourceAssembler.toFullResource(submissionEnvelope));
+        return response;
     }
 
     @RequestMapping(path = "/submissionEnvelopes/{id}" + Links.SUBMISSION_DOCUMENTS_SM_URL, method = RequestMethod.GET)


### PR DESCRIPTION
dcp-535

- Adds a "Requested" state
- User cannot request another graph validation while in "Requested" state
- Fixes bug where UI would go from "Pending" -> "Validating" -> "Pending" -> "Validating"