### PR TITLE
DCP-321 Retry file staged update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,9 @@ dependencies {
         exclude group: 'org.mongodb', module: 'mongodb-driver'
     }
     implementation 'org.springframework.data:spring-data-rest-hal-browser'
-    implementation('org.springframework.retry:spring-retry:1.3.0') {
-        exclude group: 'org.springframework', module: 'spring-core'
-    }
+
+    implementation 'org.springframework.retry:spring-retry:1.3.1'
+    implementation 'org.springframework:spring-aspects:5.3.13'
 
     implementation 'org.apache.httpcomponents:httpcore'
     implementation 'org.apache.httpcomponents:httpmime'

--- a/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
@@ -88,9 +88,30 @@ public class FileServiceTest {
         when(fileRepository.findBySubmissionEnvelopeAndFileName(submissionEnvelope, fileMessage.getFileName())).thenReturn(files);
         when(fileRepository.save(file)).thenReturn(file);
     }
+    @Test
+    public void testCreateFileFromFileMessage() throws CoreEntityNotFoundException {
+        //given:
+        when(fileRepository.findBySubmissionEnvelopeAndFileName(submissionEnvelope, fileMessage.getFileName())).thenReturn(new ArrayList<>());
+
+        //when:
+        fileService.createFileFromFileMessage(fileMessage);
+
+        //then:
+        verify(metadataCrudService).addToSubmissionEnvelopeAndSave(any(File.class), any(SubmissionEnvelope.class));
+    }
 
     @Test
-    public void testUpdateStagedFile() throws CoreEntityNotFoundException {
+    public void testCreateFileFromFileMessageNotCreated() throws CoreEntityNotFoundException {
+        //when:
+        fileService.createFileFromFileMessage(fileMessage);
+
+        //then:
+        verify(metadataCrudService, never()).addToSubmissionEnvelopeAndSave(any(File.class), any(SubmissionEnvelope.class));
+    }
+
+
+    @Test
+    public void testUpdateFileFromFileMessage() throws CoreEntityNotFoundException {
         //when:
         fileService.updateFileFromFileMessage(fileMessage);
 
@@ -103,7 +124,7 @@ public class FileServiceTest {
     }
 
     @Test
-    public void testUpdateStagedFileRetry() throws CoreEntityNotFoundException {
+    public void testUpdateFileFromFileMessageRetry() throws CoreEntityNotFoundException {
         //given:
         when(fileRepository.save(file))
                 .thenThrow(new OptimisticLockingFailureException("Error"))

--- a/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
@@ -89,6 +89,7 @@ public class FileServiceTest {
         when(fileRepository.findBySubmissionEnvelopeAndFileName(submissionEnvelope, fileMessage.getFileName())).thenReturn(files);
         when(fileRepository.save(file)).thenReturn(file);
     }
+
     @Test
     public void testCreateFileFromFileMessage() throws CoreEntityNotFoundException {
         //given:

--- a/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
@@ -73,13 +73,14 @@ public class FileServiceTest {
     @BeforeEach
     void setUp() {
         applicationContext.getBeansWithAnnotation(MockBean.class).forEach(Mockito::reset);
+
         Checksums checksums = new Checksums("sha1", "sha256", "crc32c", "s3Etag");
         String submissionUuid = UUID.randomUUID().toString();
         String filename = "filename";
         fileMessage = new FileMessage("cloudUrl", filename, submissionUuid, "content_type", checksums, 123);
+
         submissionEnvelope = new SubmissionEnvelope("submission1");
 
-        //given:
         file = new File();
         List<File> files = new ArrayList<>();
         files.add(file);

--- a/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
@@ -1,0 +1,120 @@
+package org.humancellatlas.ingest.file;
+
+import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
+import org.humancellatlas.ingest.config.MigrationConfiguration;
+import org.humancellatlas.ingest.core.Checksums;
+import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.core.exception.CoreEntityNotFoundException;
+import org.humancellatlas.ingest.core.service.MetadataCrudService;
+import org.humancellatlas.ingest.core.service.MetadataUpdateService;
+import org.humancellatlas.ingest.file.web.FileMessage;
+import org.humancellatlas.ingest.process.ProcessRepository;
+import org.humancellatlas.ingest.state.MetadataDocumentEventHandler;
+import org.humancellatlas.ingest.state.ValidationState;
+import org.humancellatlas.ingest.submission.SubmissionEnvelope;
+import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.ApplicationContext;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+
+@SpringBootTest
+public class FileServiceTest {
+    @MockBean
+    MigrationConfiguration migrationConfiguration;
+
+    @MockBean
+    FileRepository fileRepository;
+
+    @MockBean
+    SubmissionEnvelopeRepository submissionEnvelopeRepository;
+
+    @MockBean
+    BiomaterialRepository biomaterialRepository;
+
+    @MockBean
+    ProcessRepository processRepository;
+
+    @MockBean
+    MetadataDocumentEventHandler metadataDocumentEventHandler;
+
+    @MockBean
+    MetadataCrudService metadataCrudService;
+
+    @MockBean
+    MetadataUpdateService metadataUpdateService;
+
+    @Autowired
+    FileService fileService;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    FileMessage fileMessage;
+
+    SubmissionEnvelope submissionEnvelope;
+
+    File file;
+
+    @BeforeEach
+    void setUp() {
+        applicationContext.getBeansWithAnnotation(MockBean.class).forEach(Mockito::reset);
+        Checksums checksums = new Checksums("sha1", "sha256", "crc32c", "s3Etag");
+        String submissionUuid = UUID.randomUUID().toString();
+        String filename = "filename";
+        fileMessage = new FileMessage("cloudUrl", filename, submissionUuid, "content_type", checksums, 123);
+        submissionEnvelope = new SubmissionEnvelope("submission1");
+
+        //given:
+        file = new File();
+        List<File> files = new ArrayList<>();
+        files.add(file);
+
+        when(submissionEnvelopeRepository.findByUuid(any(Uuid.class))).thenReturn(submissionEnvelope);
+        when(fileRepository.findBySubmissionEnvelopeAndFileName(submissionEnvelope, fileMessage.getFileName())).thenReturn(files);
+        when(fileRepository.save(file)).thenReturn(file);
+    }
+
+    @Test
+    public void testUpdateStagedFile() throws CoreEntityNotFoundException {
+        //when:
+        fileService.updateFileFromFileMessage(fileMessage);
+
+        //then:
+        verify(fileRepository).save(file);
+        assertThat(file.getCloudUrl()).isEqualTo(fileMessage.getCloudUrl());
+        assertThat(file.getChecksums()).isEqualTo(fileMessage.getChecksums());
+        assertThat(file.getFileContentType()).isEqualTo(fileMessage.getContentType());
+        assertThat(file.getValidationState()).isEqualTo(ValidationState.DRAFT);
+    }
+
+    @Test
+    public void testUpdateStagedFileRetry() throws CoreEntityNotFoundException {
+        //given:
+        when(fileRepository.save(file))
+                .thenThrow(new OptimisticLockingFailureException("Error"))
+                .thenReturn(file);
+
+        //when:
+        fileService.updateFileFromFileMessage(fileMessage);
+
+        //then:
+        verify(fileRepository, times(2)).save(file);
+    }
+
+}
+

--- a/src/main/java/org/humancellatlas/ingest/IngestCoreApplication.java
+++ b/src/main/java/org/humancellatlas/ingest/IngestCoreApplication.java
@@ -4,9 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.PropertySource;
 import org.springframework.context.annotation.PropertySources;
-import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.retry.annotation.EnableRetry;
+
 
 @SpringBootApplication
+@EnableRetry
 @PropertySources({
         @PropertySource("classpath:application.properties")
 })

--- a/src/main/java/org/humancellatlas/ingest/core/Checksums.java
+++ b/src/main/java/org/humancellatlas/ingest/core/Checksums.java
@@ -14,7 +14,7 @@ public class Checksums {
     @JsonProperty("s3_etag")
     private String s3Etag;
 
-    protected Checksums(String sha1, String sha256, String crc32c, String s3Etag) {
+    public Checksums(String sha1, String sha256, String crc32c, String s3Etag) {
         this.sha1 = sha1;
         this.sha256 = sha256;
         this.crc32c = crc32c;


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#321

An OptimisticLockException can happen when Core tries to update the file with the s3 URL from the Upload Service. When this exception happens, the file can stay invalid even if the file is already uploaded. The retry may lessen the chance of this happening. This seems to only happen in integration tests probably because the file is very small and the validator setting the validating/invalid state (from doing file metadata validation) and upload service sending notifications happens almost at the same time.