### PR TITLE
Manually allow graph requested event

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/core/web/Links.java
+++ b/src/main/java/org/humancellatlas/ingest/core/web/Links.java
@@ -70,6 +70,8 @@ public class Links {
     // Links to request to change to graph validation state of an envelope
     public static final String GRAPH_PENDING_REL = "graphPending";
     public static final String GRAPH_PENDING_URL = "/graphPendingEvent";
+    public static final String GRAPH_REQUESTED_REL = "graphRequested";
+    public static final String GRAPH_REQUESTED_URL = "/graphRequestedEvent";
     public static final String GRAPH_VALIDATING_REL = "graphValidating";
     public static final String GRAPH_VALIDATING_URL = "/graphValidatingEvent";
     public static final String GRAPH_VALID_REL = "graphValid";

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
@@ -326,6 +326,12 @@ public class SubmissionController {
         return this.performGraphRequest(SubmissionGraphValidationState.PENDING, submissionEnvelope, resourceAssembler);
     }
 
+    @RequestMapping(path = "/submissionEnvelopes/{id}" + Links.GRAPH_REQUESTED_URL, method = RequestMethod.PUT)
+    HttpEntity<?> graphRequestedRequest(@PathVariable("id") SubmissionEnvelope submissionEnvelope, final PersistentEntityResourceAssembler resourceAssembler) {
+        // This method is used for skipping graph validation and manually setting the state if desired to mock the flow
+        return this.performGraphRequest(SubmissionGraphValidationState.REQUESTED, submissionEnvelope, resourceAssembler);
+    }
+
     @RequestMapping(path = "/submissionEnvelopes/{id}" + Links.GRAPH_VALIDATING_URL, method = RequestMethod.PUT)
     HttpEntity<?> graphValidatingRequest(@PathVariable("id") SubmissionEnvelope submissionEnvelope, final PersistentEntityResourceAssembler resourceAssembler) {
         return this.performGraphRequest(SubmissionGraphValidationState.VALIDATING, submissionEnvelope, resourceAssembler);


### PR DESCRIPTION
 Allow graphValidationState to be set to "Requested" without triggering graph validation