### PR TITLE
DCP 549: Do not allow submit request if there is no valid project

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeService.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeService.java
@@ -88,8 +88,8 @@ public class SubmissionEnvelopeService {
         projectRepository.findBySubmissionEnvelopesContains(envelope)
                 .findFirst()
                 .ifPresentOrElse(
-                        project1 -> {
-                            if (!project1.getValidationState().equals(ValidationState.VALID)) {
+                        project -> {
+                            if (!project.getValidationState().equals(ValidationState.VALID)) {
                                 throw new RuntimeException((String.format(
                                         "Envelope with id %s cannot be submitted when the project is invalid.",
                                         envelope.getId()

--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeService.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeService.java
@@ -11,7 +11,6 @@ import org.humancellatlas.ingest.file.FileRepository;
 import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.patch.PatchRepository;
 import org.humancellatlas.ingest.process.ProcessRepository;
-import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
 import org.humancellatlas.ingest.state.SubmissionState;
@@ -21,8 +20,6 @@ import org.humancellatlas.ingest.submissionmanifest.SubmissionManifestRepository
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.OptimisticLockingFailureException;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.stereotype.Service;
 


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#549

If the project is created first and not in the spreadsheet submission, the overall submission state doesn't take into consideration the project validation state. This is okay before because the user cannot upload a submission if the project is invalid. But now we want to allow users to update the project and add entities at the same time during spreadsheet upload. An additional check is needed to allow the submit request to happen.