### PR TITLE
Auto capitalize valdiation states

### DIFF
--- a/src/integration/java/org/humancellatlas/ingest/file/FileControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileControllerTest.java
@@ -1,11 +1,14 @@
 package org.humancellatlas.ingest.file;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.assertj.core.data.MapEntry;
 import org.humancellatlas.ingest.config.MigrationConfiguration;
 import org.humancellatlas.ingest.core.MetadataDocument;
 import org.humancellatlas.ingest.core.service.ValidationStateChangeService;
 import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.process.Process;
 import org.humancellatlas.ingest.process.ProcessRepository;
+import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.state.ValidationState;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -13,15 +16,22 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.entry;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -39,6 +49,9 @@ public class FileControllerTest {
 
     @Autowired
     private FileRepository fileRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
 
     @MockBean
     private MigrationConfiguration migrationConfiguration;
@@ -211,5 +224,29 @@ public class FileControllerTest {
         Arrays.stream(values).forEach(value -> {
             verify(validationStateChangeService, times(1)).changeValidationState(value.getType(), value.getId(), ValidationState.DRAFT);
         });
+    }
+
+    @Test
+    public void testValidationJobPatch() throws Exception {
+        //given:
+        File file = new File("test");
+        file = fileRepository.save(file);
+
+        //when:
+        String patch = "{ \"validationJob\": { \"validationReport\": { \"validationState\": \"Valid\" }}}";
+
+        MvcResult result = webApp
+                .perform(patch("/files/{id}", file.getId())
+                        .contentType(APPLICATION_JSON_VALUE)
+                        .content(patch))
+                .andReturn();
+
+        //expect:
+        MockHttpServletResponse response = result.getResponse();
+        assertThat(response.getContentType()).containsPattern("application/.*json.*");
+
+        //and:
+        file = fileRepository.findById(file.getId()).get();
+        assertThat(file.getValidationJob().getValidationReport().getValidationState()).isEqualTo(ValidationState.VALID);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/state/ValidationState.java
+++ b/src/main/java/org/humancellatlas/ingest/state/ValidationState.java
@@ -1,5 +1,9 @@
 package org.humancellatlas.ingest.state;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+
+import javax.validation.Valid;
+
 /**
  * Created by rolando on 07/09/2017.
  */
@@ -9,5 +13,12 @@ public enum ValidationState {
     VALID,
     INVALID,
     PROCESSING,
-    COMPLETE
+    COMPLETE;
+
+    @JsonCreator
+    public static ValidationState fromString(String key) {
+        return key == null
+                ? null
+                : ValidationState.valueOf(key.toUpperCase());
+    }
 }

--- a/src/test/java/org/humancellatlas/ingest/state/ValidationStateTest.java
+++ b/src/test/java/org/humancellatlas/ingest/state/ValidationStateTest.java
@@ -1,0 +1,31 @@
+package org.humancellatlas.ingest.state;
+
+import org.humancellatlas.ingest.file.ValidationReport;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+
+@JsonTest
+public class ValidationStateTest {
+    @Autowired
+    private JacksonTester<ValidationReport> json;
+
+    @Test
+    public void testFromString() throws Exception{
+        var jsonValue = "{ \"validationState\": \"Invalid\" }";
+        assertThat(json.parse(jsonValue).getObject().getValidationState()).isEqualTo(ValidationState.INVALID);
+
+        jsonValue = "{ \"validationState\": \"INVALID\" }";
+        assertThat(json.parse(jsonValue).getObject().getValidationState()).isEqualTo(ValidationState.INVALID);
+
+        jsonValue = "{ \"validationState\": \"Valid\" }";
+        assertThat(json.parse(jsonValue).getObject().getValidationState()).isEqualTo(ValidationState.VALID);
+
+        jsonValue = "{ \"validationState\": \"valid\" }";
+        assertThat(json.parse(jsonValue).getObject().getValidationState()).isEqualTo(ValidationState.VALID);
+    }
+}


### PR DESCRIPTION
This should fix an error I found while investigating [this ticket](https://app.zenhub.com/workspaces/operations-5fa2d8f2df78bb000f7fb2b5/issues/ebi-ait/hca-ebi-wrangler-central/621)

![image](https://user-images.githubusercontent.com/5579270/151587187-5ab94b06-f1a3-4da2-a1c5-afa4191a1fbe.png)


The validator sends a validationJob with valdiationState set to "Valid" -> This does serialize to a correct value for the enum since it should be capitalized. I have not seen anywhere else in the validator where capitalizion occurs prior to sending a patch/update to core, so I decided that the best place to do this was in core itself.