### PR TITLE
Ignore lazy dbrefs 

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/project/Project.java
+++ b/src/main/java/org/humancellatlas/ingest/project/Project.java
@@ -31,10 +31,12 @@ import java.util.stream.Collectors;
 @EqualsAndHashCode(callSuper = true)
 public class Project extends MetadataDocument {
     @RestResource
+    @JsonIgnore
     @DBRef(lazy = true)
     private Set<File> supplementaryFiles = new HashSet<>();
 
     // A project may have 1 or more submissions related to it.
+    @JsonIgnore
     private @DBRef(lazy = true)
     Set<SubmissionEnvelope> submissionEnvelopes = new HashSet<>();
 


### PR DESCRIPTION
dcp-537

When the project is resolved through `ProjectRespository` all lazy `DBRef`s are also resolved which causes an infinite recursion error in the specific project mentioned in this ticket `2ad191cd-bd7a-409b-9bd1-e72b5e4cce81`. Using `JsonIgnore` annotation on them fixes this.

See:
- https://stackoverflow.com/questions/58064639/cooperation-mongodb-lazy-loading-with-jackson-jsonignore-in-springboot-rest-con
- https://stackoverflow.com/questions/43480130/spring-data-mongo-lazy-load-rest-jackson