### PR TITLE
dcp-659 Send delete request to State Tracker and remove other links to document before deleting

### DIFF
--- a/src/integration/java/org/humancellatlas/ingest/file/FileControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileControllerTest.java
@@ -222,6 +222,7 @@ public class FileControllerTest {
 
     @Test
     public void testValidationJobPatch() throws Exception {
+        // ToDo: This test runs against a real mongo database and can fail if it is not empty.
         //given:
         File file = new File("test");
         file = fileRepository.save(file);

--- a/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionLinkMapControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionLinkMapControllerTest.java
@@ -58,6 +58,7 @@ public class SubmissionLinkMapControllerTest {
 
     @Test
     public void testSubmissionLinkMap() {
+        // ToDo: This test runs against a real mongo database and can fail if it is not empty.
         //given:
         SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope("link-map-test");
 

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/Biomaterial.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/Biomaterial.java
@@ -56,6 +56,7 @@ public class Biomaterial extends MetadataDocument {
     }
 
     public Biomaterial(String id) {
+        super(EntityType.BIOMATERIAL, null);
         this.id = id;
     }
     /**

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/BiomaterialRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/BiomaterialRepository.java
@@ -33,6 +33,9 @@ public interface BiomaterialRepository extends MongoRepository<Biomaterial, Stri
     Page<Biomaterial> findByProject(Project project, Pageable pageable);
 
     @RestResource(exported = false)
+    Stream<Biomaterial> findByProject(Project project);
+
+    @RestResource(exported = false)
     Stream<Biomaterial> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 
     @RestResource(exported = false)

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/BiomaterialRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/BiomaterialRepository.java
@@ -36,6 +36,9 @@ public interface BiomaterialRepository extends MongoRepository<Biomaterial, Stri
     Stream<Biomaterial> findByProject(Project project);
 
     @RestResource(exported = false)
+    Stream<Biomaterial> findByProjectsContaining(Project project);
+    
+    @RestResource(exported = false)
     Stream<Biomaterial> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 
     @RestResource(exported = false)

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
@@ -8,6 +8,7 @@ import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.biomaterial.BiomaterialService;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.core.service.MetadataCrudService;
 import org.humancellatlas.ingest.core.service.MetadataLinkingService;
 import org.humancellatlas.ingest.core.service.MetadataUpdateService;
 import org.humancellatlas.ingest.core.service.UriToEntityConversionService;
@@ -54,6 +55,8 @@ public class BiomaterialController {
     private final @NonNull BiomaterialRepository biomaterialRepository;
 
     private final @NonNull PagedResourcesAssembler pagedResourcesAssembler;
+
+    private final @NonNull MetadataCrudService metadataCrudService;
 
     private final @NonNull MetadataUpdateService metadataUpdateService;
 
@@ -137,6 +140,12 @@ public class BiomaterialController {
                                                       @PathVariable("processId") Process process,
                                                       PersistentEntityResourceAssembler assembler) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         metadataLinkingService.removeLink(biomaterial, process, "derivedByProcesses");
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping(path = "/biomaterials/{id}")
+    ResponseEntity<?> deleteBiomaterial(@PathVariable("id") Biomaterial biomaterial) {
+        metadataCrudService.unlinkAndDeleteDocument(biomaterial);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
@@ -145,7 +145,7 @@ public class BiomaterialController {
 
     @DeleteMapping(path = "/biomaterials/{id}")
     ResponseEntity<?> deleteBiomaterial(@PathVariable("id") Biomaterial biomaterial) {
-        metadataCrudService.unlinkAndDeleteDocument(biomaterial);
+        metadataCrudService.deleteDocument(biomaterial);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/config/ConfigurationService.java
+++ b/src/main/java/org/humancellatlas/ingest/config/ConfigurationService.java
@@ -20,6 +20,8 @@ public class ConfigurationService implements InitializingBean {
     private String documentStatesPathString;
     @Value("${STATE_TRACKER_DOCUMENT_STATES_UPDATE_PATH:state-updates/metadata-documents}")
     private String documentStatesUpdatePathString;
+    @Value("${STATE_TRACKER_DOCUMENT_PARAM:document-id}")
+    private String documentIdParamNameString;
 
     @Getter
     private String stateTrackerScheme;
@@ -31,6 +33,8 @@ public class ConfigurationService implements InitializingBean {
     private String documentStatesPath;
     @Getter
     private String documentStatesUpdatePath;
+    @Getter
+    private String documentIdParamName;
 
     private void init(){
         this.stateTrackerScheme = this.stateTrackerSchemeString;
@@ -38,6 +42,7 @@ public class ConfigurationService implements InitializingBean {
         this.stateTrackerPort = Integer.parseInt(this.stateTrackerPortString);
         this.documentStatesPath = this.documentStatesPathString;
         this.documentStatesUpdatePath = this.documentStatesUpdatePathString;
+        this.documentIdParamName = this.documentIdParamNameString;
     }
 
     @Override

--- a/src/main/java/org/humancellatlas/ingest/config/ConfigurationService.java
+++ b/src/main/java/org/humancellatlas/ingest/config/ConfigurationService.java
@@ -20,7 +20,7 @@ public class ConfigurationService implements InitializingBean {
     private String documentStatesPathString;
     @Value("${STATE_TRACKER_DOCUMENT_STATES_UPDATE_PATH:state-updates/metadata-documents}")
     private String documentStatesUpdatePathString;
-    @Value("${STATE_TRACKER_DOCUMENT_PARAM:document-id}")
+    @Value("${STATE_TRACKER_DOCUMENT_PARAM:metadataDocumentId}")
     private String documentIdParamNameString;
 
     @Getter

--- a/src/main/java/org/humancellatlas/ingest/config/ConfigurationService.java
+++ b/src/main/java/org/humancellatlas/ingest/config/ConfigurationService.java
@@ -22,6 +22,8 @@ public class ConfigurationService implements InitializingBean {
     private String documentStatesUpdatePathString;
     @Value("${STATE_TRACKER_DOCUMENT_PARAM:metadataDocumentId}")
     private String documentIdParamNameString;
+    @Value("${STATE_TRACKER_DOCUMENT_PARAM:envelopeId}")
+    private String envelopeIdParamNameString;
 
     @Getter
     private String stateTrackerScheme;
@@ -35,6 +37,8 @@ public class ConfigurationService implements InitializingBean {
     private String documentStatesUpdatePath;
     @Getter
     private String documentIdParamName;
+    @Getter
+    private String envelopeIdParamName;
 
     private void init(){
         this.stateTrackerScheme = this.stateTrackerSchemeString;
@@ -43,6 +47,7 @@ public class ConfigurationService implements InitializingBean {
         this.documentStatesPath = this.documentStatesPathString;
         this.documentStatesUpdatePath = this.documentStatesUpdatePathString;
         this.documentIdParamName = this.documentIdParamNameString;
+        this.envelopeIdParamName = this.envelopeIdParamNameString;
     }
 
     @Override

--- a/src/main/java/org/humancellatlas/ingest/core/service/MetadataCrudService.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/MetadataCrudService.java
@@ -66,4 +66,9 @@ public class MetadataCrudService {
     public <T extends MetadataDocument> Collection<T> findAllBySubmission(SubmissionEnvelope submissionEnvelope, EntityType entityType) {
         return crudStrategyForMetadataType(entityType).findAllBySubmissionEnvelope(submissionEnvelope);
     }
+
+    public <T extends MetadataDocument> void unlinkAndDeleteDocument(T metadataDocument) {
+        crudStrategyForMetadataType(metadataDocument.getType()).unlinkAndDeleteDocument(metadataDocument);
+
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/MetadataCrudService.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/MetadataCrudService.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import org.humancellatlas.ingest.core.EntityType;
 import org.humancellatlas.ingest.core.MetadataDocument;
-import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
 import org.humancellatlas.ingest.core.service.strategy.impl.*;
 import org.humancellatlas.ingest.state.ValidationState;
@@ -12,8 +11,6 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.stereotype.Service;
 
 import java.util.Collection;
-import java.util.Optional;
-import java.util.stream.Stream;
 
 @Service
 @AllArgsConstructor
@@ -67,8 +64,12 @@ public class MetadataCrudService {
         return crudStrategyForMetadataType(entityType).findAllBySubmissionEnvelope(submissionEnvelope);
     }
 
-    public <T extends MetadataDocument> void unlinkAndDeleteDocument(T metadataDocument) {
-        crudStrategyForMetadataType(metadataDocument.getType()).unlinkAndDeleteDocument(metadataDocument);
+    public <T extends MetadataDocument> void removeLinksToDocument(T metadataDocument) {
+        crudStrategyForMetadataType(metadataDocument.getType()).removeLinksToDocument(metadataDocument);
+    }
+
+    public <T extends MetadataDocument> void deleteDocument(T metadataDocument) {
+        crudStrategyForMetadataType(metadataDocument.getType()).deleteDocument(metadataDocument);
 
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/MetadataCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/MetadataCrudStrategy.java
@@ -12,4 +12,5 @@ public interface MetadataCrudStrategy <T extends MetadataDocument> {
     T findOriginalByUuid(String uuid);
     Stream<T> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
     Collection<T> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
+    void unlinkAndDeleteDocument(T document);
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/MetadataCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/MetadataCrudStrategy.java
@@ -6,11 +6,18 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import java.util.Collection;
 import java.util.stream.Stream;
 
-public interface MetadataCrudStrategy <T extends MetadataDocument> {
+public interface MetadataCrudStrategy<T extends MetadataDocument> {
     T saveMetadataDocument(T document);
+
     T findMetadataDocument(String id);
+
     T findOriginalByUuid(String uuid);
+
     Stream<T> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
+
     Collection<T> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
-    void unlinkAndDeleteDocument(T document);
+
+    void removeLinksToDocument(T document);
+
+    void deleteDocument(T document);
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
@@ -5,7 +5,6 @@ import lombok.NonNull;
 import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
-import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -52,8 +51,13 @@ public class BiomaterialCrudStrategy implements MetadataCrudStrategy<Biomaterial
     }
 
     @Override
-    public void unlinkAndDeleteDocument(Biomaterial document) {
-        document.setValidationState(ValidationState.VALID);
+    public void removeLinksToDocument(Biomaterial document) {
+        // ToDo: Tell state tracker to remove this document
+    }
+
+    @Override
+    public void deleteDocument(Biomaterial document) {
+        removeLinksToDocument(document);
         biomaterialRepository.delete(document);
     }
 

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
+import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -18,6 +19,7 @@ import java.util.stream.Stream;
 @Component
 public class BiomaterialCrudStrategy implements MetadataCrudStrategy<Biomaterial> {
     private final @NonNull BiomaterialRepository biomaterialRepository;
+    private final @NonNull MessageRouter messageRouter;
 
     @Override
     public Biomaterial saveMetadataDocument(Biomaterial document) {
@@ -52,7 +54,7 @@ public class BiomaterialCrudStrategy implements MetadataCrudStrategy<Biomaterial
 
     @Override
     public void removeLinksToDocument(Biomaterial document) {
-        // ToDo: Tell state tracker to remove this document
+        messageRouter.routeStateTrackingDeleteMessageFor(document);
     }
 
     @Override

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
+import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -52,8 +53,8 @@ public class BiomaterialCrudStrategy implements MetadataCrudStrategy<Biomaterial
 
     @Override
     public void unlinkAndDeleteDocument(Biomaterial document) {
-        // set valid
-        // delete
+        document.setValidationState(ValidationState.VALID);
+        biomaterialRepository.delete(document);
     }
 
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java
@@ -49,4 +49,11 @@ public class BiomaterialCrudStrategy implements MetadataCrudStrategy<Biomaterial
     public Collection<Biomaterial> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return biomaterialRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
+
+    @Override
+    public void unlinkAndDeleteDocument(Biomaterial document) {
+        // set valid
+        // delete
+    }
+
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
 import org.humancellatlas.ingest.file.File;
 import org.humancellatlas.ingest.file.FileRepository;
+import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
@@ -19,6 +20,7 @@ import java.util.stream.Stream;
 public class FileCrudStrategy implements MetadataCrudStrategy<File> {
     private final @NonNull FileRepository fileRepository;
     private final @NonNull ProjectRepository projectRepository;
+    private final @NonNull MessageRouter messageRouter;
 
     @Override
     public File saveMetadataDocument(File document) {
@@ -53,7 +55,7 @@ public class FileCrudStrategy implements MetadataCrudStrategy<File> {
 
     @Override
     public void removeLinksToDocument(File document) {
-        // ToDo: Tell state tracker to remove this document
+        messageRouter.routeStateTrackingDeleteMessageFor(document);
         projectRepository.findBySupplementaryFilesContains(document).forEach(project -> {
             project.getSupplementaryFiles().remove(document);
             projectRepository.save(project);

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java
@@ -6,7 +6,6 @@ import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
 import org.humancellatlas.ingest.file.File;
 import org.humancellatlas.ingest.file.FileRepository;
 import org.humancellatlas.ingest.project.ProjectRepository;
-import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -53,12 +52,17 @@ public class FileCrudStrategy implements MetadataCrudStrategy<File> {
     }
 
     @Override
-    public void unlinkAndDeleteDocument(File document) {
-        document.setValidationState(ValidationState.VALID);
+    public void removeLinksToDocument(File document) {
+        // ToDo: Tell state tracker to remove this document
         projectRepository.findBySupplementaryFilesContains(document).forEach(project -> {
             project.getSupplementaryFiles().remove(document);
             projectRepository.save(project);
         });
+    }
+
+    @Override
+    public void deleteDocument(File document) {
+        removeLinksToDocument(document);
         fileRepository.delete(document);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java
@@ -48,4 +48,11 @@ public class FileCrudStrategy implements MetadataCrudStrategy<File> {
     public Collection<File> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return fileRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
+
+    @Override
+    public void unlinkAndDeleteDocument(File document) {
+        // set valid
+        // remove from project.supplementaryFiles
+        // delete
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
 import org.humancellatlas.ingest.file.FileRepository;
+import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.process.Process;
 import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
@@ -21,6 +22,7 @@ public class ProcessCrudStrategy implements MetadataCrudStrategy<Process> {
     private final @NonNull ProcessRepository processRepository;
     private final @NonNull FileRepository fileRepository;
     private final @NonNull BiomaterialRepository biomaterialRepository;
+    private final @NonNull MessageRouter messageRouter;
 
     @Override
     public Process saveMetadataDocument(Process document) {
@@ -55,7 +57,7 @@ public class ProcessCrudStrategy implements MetadataCrudStrategy<Process> {
 
     @Override
     public void removeLinksToDocument(Process document) {
-        // ToDo: Tell state tracker to remove this document
+        messageRouter.routeStateTrackingDeleteMessageFor(document);
         fileRepository.findByInputToProcessesContains(document).forEach(file -> {
             file.getInputToProcesses().remove(document);
             fileRepository.save(file);

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java
@@ -48,4 +48,15 @@ public class ProcessCrudStrategy implements MetadataCrudStrategy<Process> {
     public Collection<Process> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return processRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
+
+    @Override
+    public void unlinkAndDeleteDocument(Process document) {
+        // set valid
+        // remove from any biomaterial.inputToProcesses
+        // remove from any biomaterial derivedByProcesses
+        // remove from any file.inputToProcesses
+        // remove from any file.derivedByProcesses
+        // remove from any other process.chainedProcesses
+        // delete
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java
@@ -7,7 +7,6 @@ import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
 import org.humancellatlas.ingest.file.FileRepository;
 import org.humancellatlas.ingest.process.Process;
 import org.humancellatlas.ingest.process.ProcessRepository;
-import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -55,8 +54,8 @@ public class ProcessCrudStrategy implements MetadataCrudStrategy<Process> {
     }
 
     @Override
-    public void unlinkAndDeleteDocument(Process document) {
-        document.setValidationState(ValidationState.VALID);
+    public void removeLinksToDocument(Process document) {
+        // ToDo: Tell state tracker to remove this document
         fileRepository.findByInputToProcessesContains(document).forEach(file -> {
             file.getInputToProcesses().remove(document);
             fileRepository.save(file);
@@ -73,6 +72,12 @@ public class ProcessCrudStrategy implements MetadataCrudStrategy<Process> {
             biomaterial.getDerivedByProcesses().remove(document);
             biomaterialRepository.save(biomaterial);
         });
+
+    }
+
+    @Override
+    public void deleteDocument(Process document) {
+        removeLinksToDocument(document);
         processRepository.delete(document);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
@@ -66,12 +66,20 @@ public class ProjectCrudStrategy implements MetadataCrudStrategy<Project> {
             biomaterial.setProject(null);
             biomaterialRepository.save(biomaterial);
         });
+        biomaterialRepository.findByProjectsContaining(document).forEach(biomaterial -> {
+            biomaterial.getProjects().remove(document);
+            biomaterialRepository.save(biomaterial);
+        });
         fileRepository.findByProject(document).forEach(file -> {
             file.setProject(null);
             fileRepository.save(file);
         });
         processRepository.findByProject(document).forEach(process -> {
             process.setProject(null);
+            processRepository.save(process);
+        });
+        processRepository.findByProjectsContaining(document).forEach(process -> {
+            process.getProjects().remove(document);
             processRepository.save(process);
         });
         protocolRepository.findByProject(document).forEach(protocol -> {

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
 import org.humancellatlas.ingest.file.FileRepository;
+import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.project.ProjectRepository;
@@ -25,6 +26,7 @@ public class ProjectCrudStrategy implements MetadataCrudStrategy<Project> {
     private final @NonNull ProcessRepository processRepository;
     private final @NonNull FileRepository fileRepository;
     private final @NonNull BiomaterialRepository biomaterialRepository;
+    private final @NonNull MessageRouter messageRouter;
 
     @Override
     public Project saveMetadataDocument(Project document) {
@@ -59,7 +61,7 @@ public class ProjectCrudStrategy implements MetadataCrudStrategy<Project> {
 
     @Override
     public void removeLinksToDocument(Project document) {
-        // ToDo: Tell state tracker to remove this document
+        messageRouter.routeStateTrackingDeleteMessageFor(document);
         biomaterialRepository.findByProject(document).forEach(biomaterial -> {
             biomaterial.setProject(null);
             biomaterialRepository.save(biomaterial);

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
@@ -9,7 +9,6 @@ import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.project.Project;
 import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
-import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -59,8 +58,8 @@ public class ProjectCrudStrategy implements MetadataCrudStrategy<Project> {
     }
 
     @Override
-    public void unlinkAndDeleteDocument(Project document) {
-        document.setValidationState(ValidationState.VALID);
+    public void removeLinksToDocument(Project document) {
+        // ToDo: Tell state tracker to remove this document
         biomaterialRepository.findByProject(document).forEach(biomaterial -> {
             biomaterial.setProject(null);
             biomaterialRepository.save(biomaterial);
@@ -77,6 +76,12 @@ public class ProjectCrudStrategy implements MetadataCrudStrategy<Project> {
             protocol.setProject(null);
             protocolRepository.save(protocol);
         });
+
+    }
+
+    @Override
+    public void deleteDocument(Project document) {
+        removeLinksToDocument(document);
         projectRepository.delete(document);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java
@@ -49,4 +49,14 @@ public class ProjectCrudStrategy implements MetadataCrudStrategy<Project> {
     public Collection<Project> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return projectRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
+
+    @Override
+    public void unlinkAndDeleteDocument(Project document) {
+        //set valid?
+        // remove from biomaterial.projects
+        // remove from file.projects
+        // remove from process.projects
+        // remove from protocol.projects
+        // delete
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
@@ -6,7 +6,6 @@ import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
 import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
-import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -53,12 +52,17 @@ public class ProtocolCrudStrategy implements MetadataCrudStrategy<Protocol> {
     }
 
     @Override
-    public void unlinkAndDeleteDocument(Protocol document) {
-        document.setValidationState(ValidationState.VALID);
+    public void removeLinksToDocument(Protocol document) {
+        // ToDo: Tell state tracker to remove this document
         processRepository.findByProtocolsContains(document).forEach(process -> {
             process.getProtocols().remove(document);
             processRepository.save(process);
         });
+    }
+
+    @Override
+    public void deleteDocument(Protocol document) {
+        removeLinksToDocument(document);
         protocolRepository.delete(document);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
@@ -48,4 +48,11 @@ public class ProtocolCrudStrategy implements MetadataCrudStrategy<Protocol> {
     public Collection<Protocol> findAllBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope) {
         return protocolRepository.findAllBySubmissionEnvelope(submissionEnvelope);
     }
+
+    @Override
+    public void unlinkAndDeleteDocument(Protocol document) {
+        // set valid
+        // remove from processes
+        // delete
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
@@ -3,6 +3,7 @@ package org.humancellatlas.ingest.core.service.strategy.impl;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
+import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
@@ -19,6 +20,7 @@ import java.util.stream.Stream;
 public class ProtocolCrudStrategy implements MetadataCrudStrategy<Protocol> {
     private final @NonNull ProtocolRepository protocolRepository;
     private final @NonNull ProcessRepository processRepository;
+    private final @NonNull MessageRouter messageRouter;
 
     @Override
     public Protocol saveMetadataDocument(Protocol document) {
@@ -53,7 +55,7 @@ public class ProtocolCrudStrategy implements MetadataCrudStrategy<Protocol> {
 
     @Override
     public void removeLinksToDocument(Protocol document) {
-        // ToDo: Tell state tracker to remove this document
+        messageRouter.routeStateTrackingDeleteMessageFor(document);
         processRepository.findByProtocolsContains(document).forEach(process -> {
             process.getProtocols().remove(document);
             processRepository.save(process);

--- a/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
+++ b/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java
@@ -3,8 +3,10 @@ package org.humancellatlas.ingest.core.service.strategy.impl;
 import lombok.AllArgsConstructor;
 import lombok.NonNull;
 import org.humancellatlas.ingest.core.service.strategy.MetadataCrudStrategy;
+import org.humancellatlas.ingest.process.ProcessRepository;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
+import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.stereotype.Component;
@@ -17,6 +19,7 @@ import java.util.stream.Stream;
 @AllArgsConstructor
 public class ProtocolCrudStrategy implements MetadataCrudStrategy<Protocol> {
     private final @NonNull ProtocolRepository protocolRepository;
+    private final @NonNull ProcessRepository processRepository;
 
     @Override
     public Protocol saveMetadataDocument(Protocol document) {
@@ -51,8 +54,11 @@ public class ProtocolCrudStrategy implements MetadataCrudStrategy<Protocol> {
 
     @Override
     public void unlinkAndDeleteDocument(Protocol document) {
-        // set valid
-        // remove from processes
-        // delete
+        document.setValidationState(ValidationState.VALID);
+        processRepository.findByProtocolsContains(document).forEach(process -> {
+            process.getProtocols().remove(document);
+            processRepository.save(process);
+        });
+        protocolRepository.delete(document);
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/file/File.java
+++ b/src/main/java/org/humancellatlas/ingest/file/File.java
@@ -66,6 +66,7 @@ public class File extends MetadataDocument {
     }
 
     public File(String id) {
+        super(EntityType.FILE, null);
         this.id = id;
     }
 

--- a/src/main/java/org/humancellatlas/ingest/file/FileRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/file/FileRepository.java
@@ -35,6 +35,9 @@ public interface FileRepository extends MongoRepository<File, String> {
 
     Page<File> findByProject(Project project, Pageable pageable);
 
+    @RestResource(exported = false)
+    Stream<File> findByProject(Project project);
+
     @RestResource(rel = "findBySubmissionEnvelope")
     Page<File> findBySubmissionEnvelope(@Param("envelopeUri") SubmissionEnvelope submissionEnvelope, Pageable pageable);
 

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.humancellatlas.ingest.core.service.MetadataCrudService;
 import org.humancellatlas.ingest.core.service.MetadataLinkingService;
 import org.humancellatlas.ingest.core.service.MetadataUpdateService;
 import org.humancellatlas.ingest.core.service.UriToEntityConversionService;
@@ -58,6 +59,9 @@ public class FileController {
 
     @NonNull
     private final PagedResourcesAssembler pagedResourcesAssembler;
+
+    @NonNull
+    private final MetadataCrudService metadataCrudService;
 
     @NonNull
     private final MetadataUpdateService metadataUpdateService;
@@ -145,6 +149,12 @@ public class FileController {
                                                  @PathVariable("processId") Process process,
                                                  PersistentEntityResourceAssembler assembler) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
         metadataLinkingService.removeLink(file, process, "derivedByProcesses");
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping(path = "/files/{id}")
+    ResponseEntity<?> deleteFile(@PathVariable("id") File file) {
+        metadataCrudService.unlinkAndDeleteDocument(file);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
@@ -154,7 +154,7 @@ public class FileController {
 
     @DeleteMapping(path = "/files/{id}")
     ResponseEntity<?> deleteFile(@PathVariable("id") File file) {
-        metadataCrudService.unlinkAndDeleteDocument(file);
+        metadataCrudService.deleteDocument(file);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/messaging/MessageRouter.java
+++ b/src/main/java/org/humancellatlas/ingest/messaging/MessageRouter.java
@@ -81,17 +81,23 @@ public class MessageRouter {
     }
 
     public boolean routeStateTrackingDeleteMessageFor(MetadataDocument document) {
+        if (document.getSubmissionEnvelope() == null) {
+            throw new RuntimeException("The metadata document should have a link to a submission envelope.");
+        }
+
         URI documentDeleteUri = UriComponentsBuilder.newInstance()
             .scheme(configurationService.getStateTrackerScheme())
             .host(configurationService.getStateTrackerHost())
             .port(configurationService.getStateTrackerPort())
             .pathSegment(configurationService.getDocumentStatesUpdatePath())
             .queryParam(configurationService.getDocumentIdParamName(), document.getId())
+            .queryParam(configurationService.getEnvelopeIdParamName(), document.getSubmissionEnvelope().getId())
             .build().toUri();
         this.messageSender.queueDocumentStateDeleteMessage(
             documentDeleteUri,
             document.getUpdateDate().toEpochMilli()
         );
+        System.out.println("ROuted message");
         return true;
     }
 

--- a/src/main/java/org/humancellatlas/ingest/messaging/MessageRouter.java
+++ b/src/main/java/org/humancellatlas/ingest/messaging/MessageRouter.java
@@ -80,6 +80,21 @@ public class MessageRouter {
         return true;
     }
 
+    public boolean routeStateTrackingDeleteMessageFor(MetadataDocument document) {
+        URI documentDeleteUri = UriComponentsBuilder.newInstance()
+            .scheme(configurationService.getStateTrackerScheme())
+            .host(configurationService.getStateTrackerHost())
+            .port(configurationService.getStateTrackerPort())
+            .pathSegment(configurationService.getDocumentStatesUpdatePath())
+            .queryParam(configurationService.getDocumentIdParamName(), document.getId())
+            .build().toUri();
+        this.messageSender.queueDocumentStateDeleteMessage(
+            documentDeleteUri,
+            document.getUpdateDate().toEpochMilli()
+        );
+        return true;
+    }
+
     public boolean routeStateTrackingUpdateMessageForEnvelopeEvent(SubmissionEnvelope envelope, SubmissionState state) {
         // TODO: call this when a user requests a state change on an envelope
         this.messageSender.queueStateTrackingMessage(Constants.Exchanges.STATE_TRACKING_EXCHANGE,

--- a/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
+++ b/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
@@ -64,7 +64,11 @@ public class MessageSender {
     }
 
     public void queueDocumentStateUpdateMessage(URI uri, Object payload, long intendedSendTime) {
-        MessageBuffer.STATE_TRACKING.queueHttpMessage(uri, payload, intendedSendTime);
+        MessageBuffer.STATE_TRACKING.queueHttpMessage(uri, HttpMethod.POST, payload, intendedSendTime);
+    }
+
+    public void queueDocumentStateDeleteMessage(URI uri, long intendedSendTime) {
+        MessageBuffer.STATE_TRACKING.queueHttpMessage(uri, HttpMethod.DELETE, new Object(), intendedSendTime);
     }
 
     public void queueUploadManagerMessage(String exchange, String routingKey,
@@ -91,12 +95,12 @@ public class MessageSender {
 
     @Data
     static class QueuedMessage implements Delayed {
-
         private final MessageProtocol messageProtocol;
+        private final Object payload;
         private String exchange;
         private String routingKey;
         private URI uri;
-        private final Object payload;
+        private HttpMethod method;
 
         private final long intendedStartTime;
 
@@ -108,8 +112,9 @@ public class MessageSender {
             this.intendedStartTime = intendedStartTime;
         }
 
-        public QueuedMessage(URI uri, Object payload, long intendedStartTime) {
+        public QueuedMessage(URI uri, HttpMethod method, Object payload, long intendedStartTime) {
             this.messageProtocol = MessageProtocol.HTTP;
+            this.method = method;
             this.uri = uri;
             this.payload = payload;
             this.intendedStartTime = intendedStartTime;
@@ -165,8 +170,8 @@ public class MessageSender {
             }
         }
 
-        void queueHttpMessage(URI uri, Object payload, long intendedStartTime) {
-            QueuedMessage message = new QueuedMessage(uri, payload, intendedStartTime + delayMillis);
+        void queueHttpMessage(URI uri, HttpMethod method, Object payload, long intendedStartTime) {
+            QueuedMessage message = new QueuedMessage(uri, method, payload, intendedStartTime + delayMillis);
             try {
                 messageQueue.add(message);
             } catch (IllegalStateException e) {
@@ -212,7 +217,7 @@ public class MessageSender {
                     messagingTemplate.convertAndSend(message.exchange, message.routingKey, message.payload);
                 } else {
                     try {
-                        restTemplate.exchange(message.getUri(), HttpMethod.POST, new HttpEntity<>(message.getPayload(), headers), Object.class);
+                        restTemplate.exchange(message.getUri(), message.method, new HttpEntity<>(message.getPayload(), headers), Object.class);
                     } catch (Exception e) {
                         log.error("", e);
                     }

--- a/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
+++ b/src/main/java/org/humancellatlas/ingest/messaging/MessageSender.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
 import java.net.URI;
 import java.util.*;
@@ -68,7 +69,7 @@ public class MessageSender {
     }
 
     public void queueDocumentStateDeleteMessage(URI uri, long intendedSendTime) {
-        MessageBuffer.STATE_TRACKING.queueHttpMessage(uri, HttpMethod.DELETE, new Object(), intendedSendTime);
+        MessageBuffer.STATE_TRACKING.queueHttpMessage(uri, HttpMethod.DELETE, null, intendedSendTime);
     }
 
     public void queueUploadManagerMessage(String exchange, String routingKey,
@@ -112,7 +113,7 @@ public class MessageSender {
             this.intendedStartTime = intendedStartTime;
         }
 
-        public QueuedMessage(URI uri, HttpMethod method, Object payload, long intendedStartTime) {
+        public QueuedMessage(URI uri, HttpMethod method, @Nullable Object payload, long intendedStartTime) {
             this.messageProtocol = MessageProtocol.HTTP;
             this.method = method;
             this.uri = uri;
@@ -170,7 +171,7 @@ public class MessageSender {
             }
         }
 
-        void queueHttpMessage(URI uri, HttpMethod method, Object payload, long intendedStartTime) {
+        void queueHttpMessage(URI uri, HttpMethod method, @Nullable Object payload, long intendedStartTime) {
             QueuedMessage message = new QueuedMessage(uri, method, payload, intendedStartTime + delayMillis);
             try {
                 messageQueue.add(message);

--- a/src/main/java/org/humancellatlas/ingest/process/Process.java
+++ b/src/main/java/org/humancellatlas/ingest/process/Process.java
@@ -49,6 +49,7 @@ public class Process extends MetadataDocument {
     Set<Process> chainedProcesses = new HashSet<>();
 
     public Process() {
+        super(EntityType.PROCESS, null);
     }
 
     @JsonCreator
@@ -57,6 +58,7 @@ public class Process extends MetadataDocument {
     }
 
     public Process(String id) {
+        super(EntityType.PROCESS, null);
         this.id = id;
     }
 

--- a/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
@@ -33,6 +33,9 @@ public interface ProcessRepository extends MongoRepository<Process, String> {
     @RestResource(exported = false)
     Stream<Process> findByProject(Project project);
 
+    @RestResource(exported = false)
+    Stream<Process> findByProjectsContaining(Project project);
+    
     Page<Process> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 
     @RestResource(exported = false)

--- a/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/process/ProcessRepository.java
@@ -30,6 +30,9 @@ public interface ProcessRepository extends MongoRepository<Process, String> {
 
     Page<Process> findByProject(Project project, Pageable pageable);
 
+    @RestResource(exported = false)
+    Stream<Process> findByProject(Project project);
+
     Page<Process> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 
     @RestResource(exported = false)

--- a/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
+++ b/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
@@ -214,7 +214,7 @@ public class ProcessController {
 
     @DeleteMapping(path = "/processes/{id}")
     ResponseEntity<?> deleteProcess(@PathVariable("id") Process process) {
-        metadataCrudService.unlinkAndDeleteDocument(process);
+        metadataCrudService.deleteDocument(process);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
+++ b/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
@@ -6,6 +6,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.core.service.MetadataCrudService;
 import org.humancellatlas.ingest.core.service.MetadataLinkingService;
 import org.humancellatlas.ingest.core.service.MetadataUpdateService;
 import org.humancellatlas.ingest.core.service.UriToEntityConversionService;
@@ -53,6 +54,7 @@ public class ProcessController {
     private final @NonNull ProcessService processService;
     private final @NonNull ProcessRepository processRepository;
     private final @NonNull PagedResourcesAssembler pagedResourcesAssembler;
+    private final @NonNull MetadataCrudService metadataCrudService;
     private final @NonNull MetadataUpdateService metadataUpdateService;
 
     private @Autowired
@@ -207,6 +209,12 @@ public class ProcessController {
                                             PersistentEntityResourceAssembler assembler) throws InvocationTargetException, NoSuchMethodException, IllegalAccessException {
 
         metadataLinkingService.removeLink(process, protocol, "protocols");
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping(path = "/processes/{id}")
+    ResponseEntity<?> deleteProcess(@PathVariable("id") Process process) {
+        metadataCrudService.unlinkAndDeleteDocument(process);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
@@ -152,7 +152,7 @@ public class ProjectService {
         ProjectBag projectBag = gather(project);
         if (projectBag.submissionEnvelopes.isEmpty()) {
             projectBag.projects.forEach(_project -> {
-                projectRepository.delete(_project);
+                metadataCrudService.unlinkAndDeleteDocument(_project);
                 projectEventHandler.deletedProject(_project);
             });
         } else {

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectService.java
@@ -152,7 +152,7 @@ public class ProjectService {
         ProjectBag projectBag = gather(project);
         if (projectBag.submissionEnvelopes.isEmpty()) {
             projectBag.projects.forEach(_project -> {
-                metadataCrudService.unlinkAndDeleteDocument(_project);
+                metadataCrudService.deleteDocument(_project);
                 projectEventHandler.deletedProject(_project);
             });
         } else {
@@ -184,7 +184,7 @@ public class ProjectService {
 
     public Page<Project> filterProjects(SearchFilter searchFilter, Pageable pageable) {
         Query query = ProjectQueryBuilder.buildProjectsQuery(searchFilter);
-        log.debug("Project Search query: " + query.toString());
+        log.debug("Project Search query: " + query);
 
         List<Project> projects = mongoTemplate.find(query.with(pageable), Project.class);
         long count = mongoTemplate.count(query, Project.class);

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -29,6 +29,7 @@ public class Protocol extends MetadataDocument {
     }
 
     public Protocol(String id) {
+        super(EntityType.PROTOCOL, null);
         this.id = id;
     }
 

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -8,7 +8,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.humancellatlas.ingest.core.EntityType;
 import org.humancellatlas.ingest.core.MetadataDocument;
-import org.humancellatlas.ingest.process.Process;
 import org.humancellatlas.ingest.project.Project;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;

--- a/src/main/java/org/humancellatlas/ingest/protocol/ProtocolRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/ProtocolRepository.java
@@ -31,6 +31,9 @@ public interface ProtocolRepository extends MongoRepository<Protocol, String> {
     public Page<Protocol> findByProject(Project project, Pageable pageable);
 
     @RestResource(exported = false)
+    Stream<Protocol> findByProject(Project project);
+
+    @RestResource(exported = false)
     public Stream<Protocol> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope);
 
     @RestResource(exported = false)

--- a/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
@@ -83,7 +83,7 @@ public class ProtocolController {
 
     @DeleteMapping(path = "/protocols/{id}")
     ResponseEntity<?> deleteProtocol(@PathVariable("id") Protocol protocol) {
-        metadataCrudService.unlinkAndDeleteDocument(protocol);
+        metadataCrudService.deleteDocument(protocol);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
@@ -5,6 +5,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.core.service.MetadataCrudService;
 import org.humancellatlas.ingest.core.service.MetadataUpdateService;
 import org.humancellatlas.ingest.patch.JsonPatcher;
 import org.humancellatlas.ingest.protocol.Protocol;
@@ -43,6 +44,7 @@ public class ProtocolController {
 
     private final @NonNull JsonPatcher jsonPatcher;
 
+    private final @NonNull MetadataCrudService metadataCrudService;
     private final @NonNull MetadataUpdateService metadataUpdateService;
 
     @RequestMapping(path = "/submissionEnvelopes/{sub_id}/protocols", method = RequestMethod.POST)
@@ -77,5 +79,11 @@ public class ProtocolController {
         Protocol updatedProtocol = metadataUpdateService.update(protocol, validPatch);
         PersistentEntityResource resource = assembler.toFullResource(updatedProtocol);
         return ResponseEntity.accepted().body(resource);
+    }
+
+    @DeleteMapping(path = "/protocols/{id}")
+    ResponseEntity<?> deleteProtocol(@PathVariable("id") Protocol protocol) {
+        metadataCrudService.unlinkAndDeleteDocument(protocol);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/BiomaterialCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/BiomaterialCrudStrategyTest.java
@@ -26,7 +26,6 @@ public class BiomaterialCrudStrategyTest {
 
     @BeforeEach
     void setUp() {
-        // ToDo: Extract the test constructors into test classes
         testBiomaterial = new Biomaterial("biomaterialId");
     }
 

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/BiomaterialCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/BiomaterialCrudStrategyTest.java
@@ -1,0 +1,40 @@
+package org.humancellatlas.ingest.core.service.strategy;
+
+import org.humancellatlas.ingest.biomaterial.Biomaterial;
+import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
+import org.humancellatlas.ingest.core.service.strategy.impl.BiomaterialCrudStrategy;
+import org.humancellatlas.ingest.messaging.MessageRouter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {BiomaterialCrudStrategy.class})
+public class BiomaterialCrudStrategyTest {
+    @Autowired private BiomaterialCrudStrategy biomaterialCrudStrategy;
+
+    @MockBean private BiomaterialRepository biomaterialRepository;
+    @MockBean private MessageRouter messageRouter;
+
+    private Biomaterial testBiomaterial;
+
+    @BeforeEach
+    void setUp() {
+        // ToDo: Extract the test constructors into test classes
+        testBiomaterial = new Biomaterial("biomaterialId");
+    }
+
+    @Test
+    public void testDeleteBiomaterial() {
+        //when
+        biomaterialCrudStrategy.deleteDocument(testBiomaterial);
+        //then
+        verify(biomaterialRepository).delete(testBiomaterial);
+    }
+}

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/FileCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/FileCrudStrategyTest.java
@@ -1,0 +1,60 @@
+package org.humancellatlas.ingest.core.service.strategy;
+
+import org.humancellatlas.ingest.core.service.strategy.impl.FileCrudStrategy;
+import org.humancellatlas.ingest.file.File;
+import org.humancellatlas.ingest.file.FileRepository;
+import org.humancellatlas.ingest.messaging.MessageRouter;
+import org.humancellatlas.ingest.project.Project;
+import org.humancellatlas.ingest.project.ProjectRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {FileCrudStrategy.class})
+public class FileCrudStrategyTest {
+    @Autowired private FileCrudStrategy fileCrudStrategy;
+
+    @MockBean private FileRepository fileRepository;
+    @MockBean private ProjectRepository projectRepository;
+    @MockBean private MessageRouter messageRouter;
+
+    private File testFile;
+
+    @BeforeEach
+    void setUp() {
+        testFile = new File("fileId");
+    }
+
+    @Test
+    public void testRemoveLinksFile() {
+        //given
+        Project projectWithFile = new Project(new Object());
+        projectWithFile.getSupplementaryFiles().add(testFile);
+        when(projectRepository.findBySupplementaryFilesContains(testFile)).thenReturn(Stream.of(projectWithFile));
+
+        // when
+        fileCrudStrategy.removeLinksToDocument(testFile);
+
+        // then
+        assertThat(projectWithFile.getSupplementaryFiles()).isEmpty();
+        verify(projectRepository).save(projectWithFile);
+    }
+
+    @Test
+    public void testDeleteFile() {
+        //when
+        fileCrudStrategy.deleteDocument(testFile);
+        //then
+        verify(fileRepository).delete(testFile);
+    }
+}

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProcessCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProcessCrudStrategyTest.java
@@ -1,0 +1,79 @@
+package org.humancellatlas.ingest.core.service.strategy;
+
+import org.humancellatlas.ingest.biomaterial.Biomaterial;
+import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
+import org.humancellatlas.ingest.core.service.strategy.impl.ProcessCrudStrategy;
+import org.humancellatlas.ingest.file.File;
+import org.humancellatlas.ingest.file.FileRepository;
+import org.humancellatlas.ingest.messaging.MessageRouter;
+import org.humancellatlas.ingest.process.Process;
+import org.humancellatlas.ingest.process.ProcessRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {ProcessCrudStrategy.class})
+public class ProcessCrudStrategyTest {
+    @Autowired private ProcessCrudStrategy processCrudStrategy;
+
+    @MockBean private BiomaterialRepository biomaterialRepository;
+    @MockBean private ProcessRepository processRepository;
+    @MockBean private FileRepository fileRepository;
+    @MockBean private MessageRouter messageRouter;
+
+    private Process testProcess;
+
+    @BeforeEach
+    void setUp() {
+        testProcess = new Process("processId");
+    }
+
+    @Test
+    public void testRemoveLinksProcess() {
+        //given
+        File inputFile = new File("inputFile");
+        File derivedFile = new File("derivedFile");
+        inputFile.getInputToProcesses().add(testProcess);
+        derivedFile.getDerivedByProcesses().add(testProcess);
+        when(fileRepository.findByInputToProcessesContains(testProcess)).thenReturn(Stream.of(inputFile));
+        when(fileRepository.findByDerivedByProcessesContains(testProcess)).thenReturn(Stream.of(derivedFile));
+
+        Biomaterial inputBio = new Biomaterial("inputBio");
+        Biomaterial derivedBio = new Biomaterial("derivedBio");
+        inputBio.getInputToProcesses().add(testProcess);
+        derivedBio.getDerivedByProcesses().add(testProcess);
+        when(biomaterialRepository.findByInputToProcessesContains(testProcess)).thenReturn(Stream.of(inputBio));
+        when(biomaterialRepository.findByDerivedByProcessesContains(testProcess)).thenReturn(Stream.of(derivedBio));
+
+        // when
+        processCrudStrategy.removeLinksToDocument(testProcess);
+
+        // then
+        assertThat(inputFile.getInputToProcesses()).isEmpty();
+        assertThat(derivedFile.getDerivedByProcesses()).isEmpty();
+        assertThat(inputBio.getInputToProcesses()).isEmpty();
+        assertThat(derivedBio.getDerivedByProcesses()).isEmpty();
+        verify(fileRepository).save(inputFile);
+        verify(fileRepository).save(derivedFile);
+        verify(biomaterialRepository).save(inputBio);
+        verify(biomaterialRepository).save(derivedBio);
+    }
+
+    @Test
+    public void testDeleteProcess() {
+        //when
+        processCrudStrategy.deleteDocument(testProcess);
+        //then
+        verify(processRepository).delete(testProcess);
+    }
+}

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProjectCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProjectCrudStrategyTest.java
@@ -1,0 +1,93 @@
+package org.humancellatlas.ingest.core.service.strategy;
+
+import org.humancellatlas.ingest.biomaterial.Biomaterial;
+import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
+import org.humancellatlas.ingest.core.service.strategy.impl.ProjectCrudStrategy;
+import org.humancellatlas.ingest.file.File;
+import org.humancellatlas.ingest.file.FileRepository;
+import org.humancellatlas.ingest.messaging.MessageRouter;
+import org.humancellatlas.ingest.process.Process;
+import org.humancellatlas.ingest.process.ProcessRepository;
+import org.humancellatlas.ingest.project.Project;
+import org.humancellatlas.ingest.project.ProjectRepository;
+import org.humancellatlas.ingest.protocol.Protocol;
+import org.humancellatlas.ingest.protocol.ProtocolRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {ProjectCrudStrategy.class})
+public class ProjectCrudStrategyTest {
+    @Autowired private ProjectCrudStrategy projectCrudStrategy;
+
+    @MockBean private ProjectRepository projectRepository;
+    @MockBean private ProtocolRepository protocolRepository;
+    @MockBean private ProcessRepository processRepository;
+    @MockBean private FileRepository fileRepository;
+    @MockBean private BiomaterialRepository biomaterialRepository;
+    @MockBean private MessageRouter messageRouter;
+
+    private Project testProject;
+
+    @BeforeEach
+    void setUp() {
+        testProject = new Project(new Object());
+    }
+
+    @Test
+    public void testRemoveLinksProject() {
+        // Given
+        Biomaterial biomaterialWithProject = new Biomaterial("biomaterial");
+        biomaterialWithProject.setProject(testProject);
+        biomaterialWithProject.getProjects().add(testProject);
+        when(biomaterialRepository.findByProject(testProject)).thenReturn(Stream.of(biomaterialWithProject));
+        when(biomaterialRepository.findByProjectsContaining(testProject)).thenReturn(Stream.of(biomaterialWithProject));
+
+        File fileWithProject = new File("file");
+        fileWithProject.setProject(testProject);
+        when(fileRepository.findByProject(testProject)).thenReturn(Stream.of(fileWithProject));
+
+        Process processWithProject = new Process("process");
+        processWithProject.setProject(testProject);
+        processWithProject.getProjects().add(testProject);
+        when(processRepository.findByProject(testProject)).thenReturn(Stream.of(processWithProject));
+        when(processRepository.findByProjectsContaining(testProject)).thenReturn(Stream.of(processWithProject));
+
+        Protocol protocolWithProject = new Protocol("protocol");
+        protocolWithProject.setProject(testProject);
+        when(protocolRepository.findByProject(testProject)).thenReturn(Stream.of(protocolWithProject));
+
+        // when
+        projectCrudStrategy.removeLinksToDocument(testProject);
+
+        //then
+        assertThat(biomaterialWithProject.getProject()).isNull();
+        assertThat(biomaterialWithProject.getProjects()).isEmpty();
+        assertThat(fileWithProject.getProject()).isNull();
+        assertThat(processWithProject.getProject()).isNull();
+        assertThat(processWithProject.getProjects()).isEmpty();
+        assertThat(protocolWithProject.getProject()).isNull();
+        verify(biomaterialRepository, times(2)).save(biomaterialWithProject);
+        verify(fileRepository).save(fileWithProject);
+        verify(processRepository, times(2)).save(processWithProject);
+        verify(protocolRepository).save(protocolWithProject);
+    }
+
+    @Test
+    public void testDeleteProject() {
+        //when
+        projectCrudStrategy.deleteDocument(testProject);
+        //then
+        verify(projectRepository).delete(testProject);
+    }
+}

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProtocolCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProtocolCrudStrategyTest.java
@@ -1,0 +1,60 @@
+package org.humancellatlas.ingest.core.service.strategy;
+
+import org.humancellatlas.ingest.core.service.strategy.impl.ProtocolCrudStrategy;
+import org.humancellatlas.ingest.messaging.MessageRouter;
+import org.humancellatlas.ingest.process.Process;
+import org.humancellatlas.ingest.process.ProcessRepository;
+import org.humancellatlas.ingest.protocol.Protocol;
+import org.humancellatlas.ingest.protocol.ProtocolRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(classes = {ProtocolCrudStrategy.class})
+public class ProtocolCrudStrategyTest {
+    @Autowired private ProtocolCrudStrategy protocolCrudStrategy;
+
+    @MockBean private ProtocolRepository  protocolRepository;
+    @MockBean private ProcessRepository processRepository;
+    @MockBean private MessageRouter messageRouter;
+
+    private Protocol testProtocol;
+
+    @BeforeEach
+    void setUp() {
+        testProtocol = new Protocol("protocolId");
+    }
+
+    @Test
+    public void testRemoveLinksProject() {
+        // given
+        Process processWithProtocol = new Process("process");
+        processWithProtocol.getProtocols().add(testProtocol);
+        when(processRepository.findByProtocolsContains(testProtocol)).thenReturn(Stream.of(processWithProtocol));
+
+        // when
+        protocolCrudStrategy.removeLinksToDocument(testProtocol);
+
+        //then
+        assertThat(processWithProtocol.getProtocols()).isEmpty();
+        verify(processRepository).save(processWithProtocol);
+    }
+
+    @Test
+    public void testDeleteProject() {
+        //when
+        protocolCrudStrategy.deleteDocument(testProtocol);
+        //then
+        verify(protocolRepository).delete(testProtocol);
+    }
+}

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -102,6 +102,7 @@ class ProjectFilterTest {
 
     @Test
     void filter_by_state() {
+        // ToDo: This test runs against a real mongo database and can fail if it is not empty.
         Project project4 = makeProject("project4");
         project4.setWranglingState(WranglingState.IN_PROGRESS);
         this.mongoTemplate.save(project4);

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -336,7 +336,7 @@ class ProjectFilterTest {
                 .hasSize(2)
                 .usingComparatorForElementFieldsWithType(upToMillies, Instant.class)
                 .usingElementComparatorIgnoringFields("supplementaryFiles", "submissionEnvelopes")
-                .containsExactly(project1, project2);
+                .containsExactlyInAnyOrder(project1, project2);
     }
     @Test
     void query_exact_phrase__correct_order(){

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
@@ -214,9 +214,10 @@ public class ProjectServiceTest {
             projectService.delete(project);
 
             //then:
-            persistentProjects.forEach(persistentProject ->
-                verify(projectRepository).delete(persistentProject)
-            );
+            persistentProjects.forEach(persistentProject -> {
+                verify(metadataCrudService).deleteDocument(persistentProject);
+                verify(projectEventHandler).deletedProject(persistentProject);
+            });
         }
 
         @Test

--- a/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
@@ -4,6 +4,7 @@ import org.humancellatlas.ingest.biomaterial.Biomaterial;
 import org.humancellatlas.ingest.biomaterial.BiomaterialRepository;
 import org.humancellatlas.ingest.bundle.BundleManifestRepository;
 import org.humancellatlas.ingest.core.Uuid;
+import org.humancellatlas.ingest.core.service.MetadataCrudService;
 import org.humancellatlas.ingest.core.service.MetadataUpdateService;
 import org.humancellatlas.ingest.errors.SubmissionErrorRepository;
 import org.humancellatlas.ingest.exporter.Exporter;
@@ -57,6 +58,9 @@ public class SubmissionEnvelopeServiceTest {
 
     @MockBean
     private Exporter exporter;
+
+    @MockBean
+    private MetadataCrudService metadataCrudService;
 
     @MockBean
     private MetadataUpdateService metadataUpdateService;
@@ -187,9 +191,9 @@ public class SubmissionEnvelopeServiceTest {
         service.deleteSubmission(submissionEnvelope, false);
 
         //then:
-        assertThat(testOutsideBiomaterial.getInputToProcesses()).doesNotContain(testProcess);
-        assertThat(testOutsideFile.getDerivedByProcesses()).doesNotContain(testProcess);
-        assertThat(testOutsideProcess.getProtocols()).doesNotContain(testProtocol);
+        verify(metadataCrudService).removeLinksToDocument(testProcess);
+        verify(metadataCrudService).removeLinksToDocument(testProtocol);
+        verify(metadataCrudService).removeLinksToDocument(file);
 
         verify(biomaterialRepository).deleteBySubmissionEnvelope(submissionEnvelope);
         verify(processRepository).deleteBySubmissionEnvelope(submissionEnvelope);
@@ -202,7 +206,6 @@ public class SubmissionEnvelopeServiceTest {
 
         verify(projectRepository).findBySubmissionEnvelope(submissionEnvelope);
         assertThat(project.getSubmissionEnvelopes()).isEmpty();
-        assertThat(project.getSupplementaryFiles()).isEmpty();
         verify(projectRepository, atLeastOnce()).save(project);
         verify(submissionEnvelopeRepository).delete(submissionEnvelope);
     }


### PR DESCRIPTION
Zenhub: dcp-659
GitHub: ebi-ait/dcp-ingest-central#659

Required for ebi-ait/ingest-ui#167

- [x] New methods metadataCrudService.unlinkAndDeleteDocument
- [x] [Project Implementation](https://github.com/ebi-ait/ingest-core/blob/ee029b50555788a231873edf68c4da9b0065a621/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProjectCrudStrategy.java)
- [x] [Biomaterial Implementation](https://github.com/ebi-ait/ingest-core/blob/ee029b50555788a231873edf68c4da9b0065a621/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/BiomaterialCrudStrategy.java)
- [x] [File Implementation](https://github.com/ebi-ait/ingest-core/blob/ee029b50555788a231873edf68c4da9b0065a621/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/FileCrudStrategy.java) 
- [x] [Process Implementation](https://github.com/ebi-ait/ingest-core/blob/ee029b50555788a231873edf68c4da9b0065a621/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProcessCrudStrategy.java)
- [x] [Protocol Implementation](https://github.com/ebi-ait/ingest-core/blob/ee029b50555788a231873edf68c4da9b0065a621/src/main/java/org/humancellatlas/ingest/core/service/strategy/impl/ProtocolCrudStrategy.java)

Dependant on: https://github.com/ebi-ait/ingest-state-tracking/pull/12