### PR TITLE
Integration test cleanup

### DIFF
--- a/src/integration/java/org/humancellatlas/ingest/biomaterial/BiomaterialControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/biomaterial/BiomaterialControllerTest.java
@@ -79,9 +79,9 @@ public class BiomaterialControllerTest {
         submissionEnvelope.enactStateTransition(SubmissionState.GRAPH_VALID);
         submissionEnvelopeRepository.save(submissionEnvelope);
 
-        process = new Process();
-        process2 = new Process();
-        process3 = new Process();
+        process = new Process(null);
+        process2 = new Process(null);
+        process3 = new Process(null);
         processRepository.saveAll(Arrays.asList(process, process2, process3));
 
         biomaterial = new Biomaterial();

--- a/src/integration/java/org/humancellatlas/ingest/biomaterial/BiomaterialControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/biomaterial/BiomaterialControllerTest.java
@@ -12,6 +12,7 @@ import org.humancellatlas.ingest.state.SubmissionState;
 import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,6 +89,14 @@ public class BiomaterialControllerTest {
         biomaterialRepository.save(biomaterial);
 
         uriBuilder = ServletUriComponentsBuilder.fromCurrentContextPath();
+    }
+
+    @AfterEach
+    private void tearDown() {
+        processRepository.deleteAll();
+        biomaterialRepository.deleteAll();
+        projectRepository.deleteAll();
+        submissionEnvelopeRepository.deleteAll();
     }
 
     @Test

--- a/src/integration/java/org/humancellatlas/ingest/file/FileControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileControllerTest.java
@@ -12,6 +12,7 @@ import org.humancellatlas.ingest.state.SubmissionState;
 import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -89,6 +90,13 @@ public class FileControllerTest {
         file.setSubmissionEnvelope(submissionEnvelope);
         fileRepository.save(file);
         uriBuilder = ServletUriComponentsBuilder.fromCurrentContextPath();
+    }
+
+    @AfterEach
+    private void tearDown() {
+        processRepository.deleteAll();
+        fileRepository.deleteAll();
+        submissionEnvelopeRepository.deleteAll();
     }
 
     @Test
@@ -238,7 +246,6 @@ public class FileControllerTest {
 
     @Test
     public void testValidationJobPatch() throws Exception {
-        // ToDo: This test runs against a real mongo database and can fail if it is not empty.
         //given:
         File file = new File("test");
         file = fileRepository.save(file);

--- a/src/integration/java/org/humancellatlas/ingest/file/FileControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileControllerTest.java
@@ -29,8 +29,7 @@ import java.util.Arrays;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -81,12 +80,12 @@ public class FileControllerTest {
         submissionEnvelope.enactStateTransition(SubmissionState.GRAPH_VALID);
         submissionEnvelopeRepository.save(submissionEnvelope);
 
-        process = new Process();
-        process2 = new Process();
-        process3 = new Process();
+        process = new Process(null);
+        process2 = new Process(null);
+        process3 = new Process(null);
         processRepository.saveAll(Arrays.asList(process, process2, process3));
 
-        file = new File(UUID.randomUUID().toString());
+        file = new File(null, "fileName");
         file.setSubmissionEnvelope(submissionEnvelope);
         fileRepository.save(file);
         uriBuilder = ServletUriComponentsBuilder.fromCurrentContextPath();
@@ -247,7 +246,7 @@ public class FileControllerTest {
     @Test
     public void testValidationJobPatch() throws Exception {
         //given:
-        File file = new File("test");
+        File file = new File(null, "test");
         file = fileRepository.save(file);
 
         //when:

--- a/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
@@ -81,7 +81,7 @@ public class FileServiceTest {
 
         submissionEnvelope = new SubmissionEnvelope("submission1");
 
-        file = new File();
+        file = new File(null, filename);
         List<File> files = new ArrayList<>();
         files.add(file);
 

--- a/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
@@ -79,7 +79,7 @@ public class FileServiceTest {
         String filename = "filename";
         fileMessage = new FileMessage("cloudUrl", filename, submissionUuid, "content_type", checksums, 123);
 
-        submissionEnvelope = new SubmissionEnvelope("submission1");
+        submissionEnvelope = new SubmissionEnvelope();
 
         file = new File(null, filename);
         List<File> files = new ArrayList<>();

--- a/src/integration/java/org/humancellatlas/ingest/process/ProcessControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/process/ProcessControllerTest.java
@@ -26,7 +26,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Arrays;
-import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -79,22 +78,16 @@ class ProcessControllerTest {
 
     @BeforeEach
     void setUp() {
-        submissionEnvelope = new SubmissionEnvelope(UUID.randomUUID().toString());
+        submissionEnvelope = new SubmissionEnvelope();
         submissionEnvelope.setUuid(Uuid.newUuid());
         submissionEnvelope.enactStateTransition(SubmissionState.GRAPH_VALID);
-        submissionEnvelopeRepository.save(submissionEnvelope);
+        submissionEnvelope = submissionEnvelopeRepository.save(submissionEnvelope);
 
-        protocol1 = new Protocol(null);
-        protocol2 = new Protocol(null);
-        protocol3 = new Protocol(null);
+        protocol1 = protocolRepository.save(new Protocol(null));
+        protocol2 = protocolRepository.save(new Protocol(null));
+        protocol3 = protocolRepository.save(new Protocol(null));
 
-        protocol1 = protocolRepository.save(protocol1);
-        protocol2 = protocolRepository.save(protocol2);
-        protocol3 = protocolRepository.save(protocol3);
-
-
-        project = new Project(null);
-        project = projectRepository.save(project);
+        project = projectRepository.save(new Project(null));
 
         process = new Process(null);
         process.setSubmissionEnvelope(submissionEnvelope);

--- a/src/integration/java/org/humancellatlas/ingest/process/ProcessControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/process/ProcessControllerTest.java
@@ -13,6 +13,7 @@ import org.humancellatlas.ingest.state.SubmissionState;
 import org.humancellatlas.ingest.state.ValidationState;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -94,6 +95,14 @@ class ProcessControllerTest {
         processRepository.save(process);
 
         uriBuilder = ServletUriComponentsBuilder.fromCurrentContextPath();
+    }
+
+    @AfterEach
+    private void tearDown() {
+        submissionEnvelopeRepository.deleteAll();
+        processRepository.deleteAll();
+        protocolRepository.deleteAll();
+        projectRepository.deleteAll();
     }
 
     @Test

--- a/src/integration/java/org/humancellatlas/ingest/process/ProcessRepositoryTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/process/ProcessRepositoryTest.java
@@ -6,6 +6,7 @@ import org.humancellatlas.ingest.config.MigrationConfiguration;
 import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -31,6 +32,12 @@ public class ProcessRepositoryTest {
 
     @MockBean
     private MessageRouter messageRouter;
+
+    @AfterEach
+    private void tearDown() {
+        processRepository.deleteAll();
+        protocolRepository.deleteAll();
+    }
 
     @Test
     public void findFirstByProtocolNonUnique() {

--- a/src/integration/java/org/humancellatlas/ingest/process/ProcessRepositoryTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/process/ProcessRepositoryTest.java
@@ -1,7 +1,6 @@
 package org.humancellatlas.ingest.process;
 
 import org.humancellatlas.ingest.config.MigrationConfiguration;
-import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.messaging.MessageRouter;
 import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
@@ -16,8 +15,6 @@ import java.util.Optional;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.spy;
 
 @DataMongoTest
 public class ProcessRepositoryTest {
@@ -43,19 +40,14 @@ public class ProcessRepositoryTest {
     @Test
     public void findFirstByProtocolNonUnique() {
         //given:
-        Protocol protocol = new Protocol(null);
+        Protocol protocol = protocolRepository.save(new Protocol(null));
+
         Process process1 = new Process(null);
-        Process process2 = new Process(null);
-
-        protocol.setUuid(Uuid.newUuid());
-        process1.setUuid(Uuid.newUuid());
-        process2.setUuid(Uuid.newUuid());
-
         process1.addProtocol(protocol);
-        process2.addProtocol(protocol);
-
-        protocol = protocolRepository.save(protocol);
         process1 = processRepository.save(process1);
+
+        Process process2 = new Process(null);
+        process2.addProtocol(protocol);
         process2 = processRepository.save(process2);
 
         //and:
@@ -63,7 +55,9 @@ public class ProcessRepositoryTest {
 
         //when:
         Optional<Process> first = processRepository.findFirstByProtocolsContains(protocol);
+
+        // then
         assertThat(first.isPresent()).isTrue();
-        assertThat(first.get().getUuid()).isIn(asList(process1.getUuid(), process2.getUuid()));
+        assertThat(first.get().getId()).isIn(asList(process1.getId(), process2.getId()));
     }
 }

--- a/src/integration/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/project/ProjectFilterTest.java
@@ -1,6 +1,5 @@
 package org.humancellatlas.ingest.project;
 
-import org.humancellatlas.ingest.ProjectJson;
 import org.humancellatlas.ingest.bundle.BundleManifestRepository;
 import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.core.service.MetadataCrudService;
@@ -102,7 +101,6 @@ class ProjectFilterTest {
 
     @Test
     void filter_by_state() {
-        // ToDo: This test runs against a real mongo database and can fail if it is not empty.
         Project project4 = makeProject("project4");
         project4.setWranglingState(WranglingState.IN_PROGRESS);
         this.mongoTemplate.save(project4);

--- a/src/integration/java/org/humancellatlas/ingest/project/ProjectJson.java
+++ b/src/integration/java/org/humancellatlas/ingest/project/ProjectJson.java
@@ -1,0 +1,35 @@
+package org.humancellatlas.ingest.project;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.util.Map;
+
+public class ProjectJson {
+    String title;
+
+    public static ProjectJson fromTitle(String title){
+        ProjectJson project = new ProjectJson();
+        project.title = title;
+        return project;
+    }
+
+    public ObjectNode toObjectNode() {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode content = mapper.createObjectNode();
+        ObjectNode projectCore0 = content.putObject("project_core");
+        projectCore0.put("project_title", this.title);
+
+        ObjectNode metadata = mapper.createObjectNode();
+        metadata.set("content", content);
+
+        return metadata;
+    }
+
+    public  Map<String, Object> toMap() {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode project = this.toObjectNode();
+        return mapper.convertValue(project, new TypeReference<Map<String, Object>>(){});
+    }
+}

--- a/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/project/web/ProjectControllerTest.java
@@ -9,6 +9,7 @@ import org.humancellatlas.ingest.project.ProjectRepository;
 import org.humancellatlas.ingest.schemas.SchemaService;
 import org.humancellatlas.ingest.state.ValidationState;
 import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -62,6 +63,11 @@ class ProjectControllerTest {
 
     @MockBean
     private SchemaService schemaService;
+
+    @AfterEach
+    private void tearDown() {
+        repository.deleteAll();
+    }
 
     @Nested
     class Update {

--- a/src/integration/java/org/humancellatlas/ingest/stagingjob/StagingJobRepositoryTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/stagingjob/StagingJobRepositoryTest.java
@@ -2,6 +2,7 @@ package org.humancellatlas.ingest.stagingjob;
 
 import org.assertj.core.api.Assertions;
 import org.humancellatlas.ingest.config.MigrationConfiguration;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -21,6 +22,12 @@ public class StagingJobRepositoryTest {
 
     @Autowired
     StagingJobRepository stagingJobRepository;
+
+
+    @AfterEach
+    private void tearDown() {
+        stagingJobRepository.deleteAll();
+    }
 
     @Test
     public void testJpaExceptionWhenInsertingMultipleCompoundKey() {

--- a/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionLinkMapControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionLinkMapControllerTest.java
@@ -12,6 +12,7 @@ import org.humancellatlas.ingest.protocol.Protocol;
 import org.humancellatlas.ingest.protocol.ProtocolRepository;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -56,9 +57,17 @@ public class SubmissionLinkMapControllerTest {
     @MockBean
     private MessageRouter messageRouter;
 
+    @AfterEach
+    private void tearDown() {
+        biomaterialRepository.deleteAll();
+        fileRepository.deleteAll();
+        processRepository.deleteAll();
+        protocolRepository.deleteAll();
+        submissionEnvelopeRepository.deleteAll();
+    }
+
     @Test
     public void testSubmissionLinkMap() {
-        // ToDo: This test runs against a real mongo database and can fail if it is not empty.
         //given:
         SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope("link-map-test");
 

--- a/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionLinkMapControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionLinkMapControllerTest.java
@@ -14,24 +14,18 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.data.mongo.AutoConfigureDataMongo;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
-@ExtendWith(SpringExtension.class)
 @SpringBootTest
-@AutoConfigureMockMvc(printOnlyOnFailure = false)
+@AutoConfigureDataMongo()
 public class SubmissionLinkMapControllerTest {
     @Autowired
     private SubmissionLinkMapController controller;
@@ -71,49 +65,49 @@ public class SubmissionLinkMapControllerTest {
         //given:
         SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope("link-map-test");
 
-        Biomaterial donor = new Biomaterial("donor");
-        Biomaterial specimen = new Biomaterial("specimen");
-        Biomaterial cellSuspension = new Biomaterial("cellSuspension");
+        Biomaterial donor = biomaterialRepository.save(new Biomaterial(null));
+        Biomaterial specimen = biomaterialRepository.save(new Biomaterial(null));
+        Biomaterial cellSuspension = biomaterialRepository.save(new Biomaterial(null));
 
-        Process process1 = new Process("donor-specimen-process");
-        Process process2 = new Process("cellSuspension-sequenceFile-process");
-        Process process3 = new Process("sequenceFile-analysisFile-process");
+        Process donorSpecimen = processRepository.save(new Process(null));
+        Process cellSuspensionSequenceFile = processRepository.save(new Process(null));
+        Process sequenceFileAnalysisFile = processRepository.save(new Process(null));
 
-        Protocol collectionProtocol = new Protocol("collectionProtocol");
-        Protocol sequencingProtocol = new Protocol("sequencingProtocol");
-        Protocol analysisProtocol = new Protocol("analysisProtocol");
+        Protocol collectionProtocol = protocolRepository.save(new Protocol(null));
+        Protocol sequencingProtocol = protocolRepository.save(new Protocol(null));
+        Protocol analysisProtocol = protocolRepository.save(new Protocol(null));
 
-        File sequencingFile = new File("sequenceFile");
-        File analysisFile = new File("analysisFile");
+        File sequencingFile = fileRepository.save(new File(null, "sequenceFile"));
+        File analysisFile = fileRepository.save(new File(null, "analysisFile"));
 
         donor.setSubmissionEnvelope(submissionEnvelope);
         specimen.setSubmissionEnvelope(submissionEnvelope);
         cellSuspension.setSubmissionEnvelope(submissionEnvelope);
-        process1.setSubmissionEnvelope(submissionEnvelope);
-        process2.setSubmissionEnvelope(submissionEnvelope);
-        process3.setSubmissionEnvelope(submissionEnvelope);
+        donorSpecimen.setSubmissionEnvelope(submissionEnvelope);
+        cellSuspensionSequenceFile.setSubmissionEnvelope(submissionEnvelope);
+        sequenceFileAnalysisFile.setSubmissionEnvelope(submissionEnvelope);
         collectionProtocol.setSubmissionEnvelope(submissionEnvelope);
         sequencingProtocol.setSubmissionEnvelope(submissionEnvelope);
         analysisProtocol.setSubmissionEnvelope(submissionEnvelope);
         sequencingFile.setSubmissionEnvelope(submissionEnvelope);
         analysisFile.setSubmissionEnvelope(submissionEnvelope);
 
-        specimen.addAsDerivedByProcess(process1);
-        sequencingFile.addAsDerivedByProcess(process2);
-        analysisFile.addAsDerivedByProcess(process3);
+        specimen.addAsDerivedByProcess(donorSpecimen);
+        sequencingFile.addAsDerivedByProcess(cellSuspensionSequenceFile);
+        analysisFile.addAsDerivedByProcess(sequenceFileAnalysisFile);
 
-        donor.addAsInputToProcess(process1);
-        cellSuspension.addAsInputToProcess(process2);
-        sequencingFile.addAsInputToProcess(process3);
+        donor.addAsInputToProcess(donorSpecimen);
+        cellSuspension.addAsInputToProcess(cellSuspensionSequenceFile);
+        sequencingFile.addAsInputToProcess(sequenceFileAnalysisFile);
 
-        process1.addProtocol(collectionProtocol);
-        process2.addProtocol(sequencingProtocol);
-        process3.addProtocol(analysisProtocol);
+        donorSpecimen.addProtocol(collectionProtocol);
+        cellSuspensionSequenceFile.addProtocol(sequencingProtocol);
+        sequenceFileAnalysisFile.addProtocol(analysisProtocol);
 
         submissionEnvelopeRepository.save(submissionEnvelope);
         biomaterialRepository.saveAll(List.of(donor, specimen, cellSuspension));
         protocolRepository.saveAll(List.of(collectionProtocol, sequencingProtocol, analysisProtocol));
-        processRepository.saveAll(List.of(process1, process2, process3));
+        processRepository.saveAll(List.of(donorSpecimen, cellSuspensionSequenceFile, sequenceFileAnalysisFile));
         fileRepository.saveAll(List.of(sequencingFile, analysisFile));
 
         //when:
@@ -121,17 +115,17 @@ public class SubmissionLinkMapControllerTest {
 
         //then:
         assertThat(submissionLinkMap).isNotNull();
-        assertThat(submissionLinkMap.processes.get("donor-specimen-process").protocols).isEqualTo(new HashSet<>(Arrays.asList("collectionProtocol")));
-        assertThat(submissionLinkMap.processes.get("donor-specimen-process").inputBiomaterials).isEqualTo(new HashSet<>(Arrays.asList("donor")));
-        assertThat(submissionLinkMap.processes.get("cellSuspension-sequenceFile-process").protocols).isEqualTo(new HashSet<>(Arrays.asList("sequencingProtocol")));
-        assertThat(submissionLinkMap.processes.get("cellSuspension-sequenceFile-process").inputBiomaterials).isEqualTo(new HashSet<>(Arrays.asList("cellSuspension")));
-        assertThat(submissionLinkMap.processes.get("cellSuspension-sequenceFile-process").inputFiles).isEmpty();
-        assertThat(submissionLinkMap.processes.get("sequenceFile-analysisFile-process").protocols).isEqualTo(new HashSet<>(Arrays.asList("analysisProtocol")));
-        assertThat(submissionLinkMap.processes.get("sequenceFile-analysisFile-process").inputBiomaterials).isEmpty();
-        assertThat(submissionLinkMap.processes.get("sequenceFile-analysisFile-process").inputFiles).isEqualTo(new HashSet<>(Arrays.asList("sequenceFile")));
-        assertThat(submissionLinkMap.biomaterials.get("donor").inputToProcesses).isEqualTo(new HashSet<>(Arrays.asList("donor-specimen-process")));
-        assertThat(submissionLinkMap.biomaterials.get("cellSuspension").inputToProcesses).isEqualTo(new HashSet<>(Arrays.asList("cellSuspension-sequenceFile-process")));
-        assertThat(submissionLinkMap.files.get("sequenceFile").inputToProcesses).isEqualTo(new HashSet<>(Arrays.asList("sequenceFile-analysisFile-process")));
+        assertThat(submissionLinkMap.processes.get(donorSpecimen.getId()).protocols).isEqualTo(new HashSet<>(List.of(collectionProtocol.getId())));
+        assertThat(submissionLinkMap.processes.get(donorSpecimen.getId()).inputBiomaterials).isEqualTo(new HashSet<>(List.of(donor.getId())));
+        assertThat(submissionLinkMap.processes.get(cellSuspensionSequenceFile.getId()).protocols).isEqualTo(new HashSet<>(List.of(sequencingProtocol.getId())));
+        assertThat(submissionLinkMap.processes.get(cellSuspensionSequenceFile.getId()).inputBiomaterials).isEqualTo(new HashSet<>(List.of(cellSuspension.getId())));
+        assertThat(submissionLinkMap.processes.get(cellSuspensionSequenceFile.getId()).inputFiles).isEmpty();
+        assertThat(submissionLinkMap.processes.get(sequenceFileAnalysisFile.getId()).protocols).isEqualTo(new HashSet<>(List.of(analysisProtocol.getId())));
+        assertThat(submissionLinkMap.processes.get(sequenceFileAnalysisFile.getId()).inputBiomaterials).isEmpty();
+        assertThat(submissionLinkMap.processes.get(sequenceFileAnalysisFile.getId()).inputFiles).isEqualTo(new HashSet<>(List.of(sequencingFile.getId())));
+        assertThat(submissionLinkMap.biomaterials.get(donor.getId()).inputToProcesses).isEqualTo(new HashSet<>(List.of(donorSpecimen.getId())));
+        assertThat(submissionLinkMap.biomaterials.get(cellSuspension.getId()).inputToProcesses).isEqualTo(new HashSet<>(List.of(cellSuspensionSequenceFile.getId())));
+        assertThat(submissionLinkMap.files.get(sequencingFile.getId()).inputToProcesses).isEqualTo(new HashSet<>(List.of(sequenceFileAnalysisFile.getId())));
     }
 
 }

--- a/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionLinkMapControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionLinkMapControllerTest.java
@@ -63,7 +63,7 @@ public class SubmissionLinkMapControllerTest {
     @Test
     public void testSubmissionLinkMap() {
         //given:
-        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope("link-map-test");
+        SubmissionEnvelope submissionEnvelope = submissionEnvelopeRepository.save(new SubmissionEnvelope());
 
         Biomaterial donor = biomaterialRepository.save(new Biomaterial(null));
         Biomaterial specimen = biomaterialRepository.save(new Biomaterial(null));

--- a/src/main/java/org/humancellatlas/ingest/biomaterial/Biomaterial.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/Biomaterial.java
@@ -55,10 +55,6 @@ public class Biomaterial extends MetadataDocument {
         super(EntityType.BIOMATERIAL, content);
     }
 
-    public Biomaterial(String id) {
-        super(EntityType.BIOMATERIAL, null);
-        this.id = id;
-    }
     /**
      * Adds to the collection of processes that this biomaterial serves as an input to
      *

--- a/src/main/java/org/humancellatlas/ingest/file/File.java
+++ b/src/main/java/org/humancellatlas/ingest/file/File.java
@@ -60,16 +60,6 @@ public class File extends MetadataDocument {
     private Long size;
     private String fileContentType;
 
-    public File() {
-        super(EntityType.FILE, null);
-        setDataFileUuid(UUID.randomUUID());
-    }
-
-    public File(String id) {
-        super(EntityType.FILE, null);
-        this.id = id;
-    }
-
     @JsonCreator
     public File(@JsonProperty("content") Object content,
                 @JsonProperty("fileName") String fileName) {

--- a/src/main/java/org/humancellatlas/ingest/process/Process.java
+++ b/src/main/java/org/humancellatlas/ingest/process/Process.java
@@ -48,18 +48,9 @@ public class Process extends MetadataDocument {
     private @DBRef
     Set<Process> chainedProcesses = new HashSet<>();
 
-    public Process() {
-        super(EntityType.PROCESS, null);
-    }
-
     @JsonCreator
     public Process(@JsonProperty("content") Object content) {
         super(EntityType.PROCESS, content);
-    }
-
-    public Process(String id) {
-        super(EntityType.PROCESS, null);
-        this.id = id;
     }
 
     public Process addInputBundleManifest(BundleManifest bundleManifest) {

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -28,11 +28,6 @@ public class Protocol extends MetadataDocument {
         super(EntityType.PROTOCOL, content);
     }
 
-    public Protocol(String id) {
-        super(EntityType.PROTOCOL, null);
-        this.id = id;
-    }
-
     public boolean isLinked() {
         return linked;
     }

--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
@@ -46,6 +46,7 @@ public class SubmissionEnvelope extends AbstractEntity {
 
     public SubmissionEnvelope(String id) {
         this();
+        // ToDo: Get rid of this?
         this.id = id;
     }
 

--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
@@ -44,12 +44,6 @@ public class SubmissionEnvelope extends AbstractEntity {
         this.submitActions = new HashSet<>();
     }
 
-    public SubmissionEnvelope(String id) {
-        this();
-        // ToDo: Get rid of this?
-        this.id = id;
-    }
-
     private static Logger getLog() {
         return log;
     }

--- a/src/test/java/org/humancellatlas/ingest/core/service/MetadataCrudServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/MetadataCrudServiceTest.java
@@ -24,8 +24,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.stream.Stream;
 
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {
@@ -53,11 +52,11 @@ public class MetadataCrudServiceTest {
 
     private static Stream<Arguments> providedTestDocuments() {
         return Stream.of(
-            Arguments.of(new Biomaterial("biomaterialId")),
-            Arguments.of(new File("fileId")),
-            Arguments.of(new Process("processId")),
-            Arguments.of(new Project(new Object())),
-            Arguments.of(new Protocol("protocolId"))
+            Arguments.of(new Biomaterial(null)),
+            Arguments.of(new File(null, "fileName")),
+            Arguments.of(new Process(null)),
+            Arguments.of(new Project(null)),
+            Arguments.of(new Protocol(null))
         );
     }
 

--- a/src/test/java/org/humancellatlas/ingest/core/service/MetadataLinkingServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/MetadataLinkingServiceTest.java
@@ -44,9 +44,12 @@ public class MetadataLinkingServiceTest {
     void setUp() {
         submission = new SubmissionEnvelope(UUID.randomUUID().toString());
         submission.enactStateTransition(SubmissionState.GRAPH_VALID);
-        protocol = new Protocol(UUID.randomUUID().toString());
-        protocol2 = new Protocol(UUID.randomUUID().toString());
-        process = new Process(UUID.randomUUID().toString());
+        protocol = spy(new Protocol(null));
+        doReturn("protocol1").when(protocol).getId();
+        protocol2 = spy(new Protocol(null));
+        doReturn("protocol2").when(protocol2).getId();
+        process = spy(new Process(null));
+        doReturn("process").when(process).getId();
         process.setSubmissionEnvelope(submission);
     }
 

--- a/src/test/java/org/humancellatlas/ingest/core/service/MetadataLinkingServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/MetadataLinkingServiceTest.java
@@ -42,7 +42,7 @@ public class MetadataLinkingServiceTest {
 
     @BeforeEach
     void setUp() {
-        submission = new SubmissionEnvelope(UUID.randomUUID().toString());
+        submission = new SubmissionEnvelope();
         submission.enactStateTransition(SubmissionState.GRAPH_VALID);
         protocol = spy(new Protocol(null));
         doReturn("protocol1").when(protocol).getId();

--- a/src/test/java/org/humancellatlas/ingest/core/service/MetadataUpdateServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/MetadataUpdateServiceTest.java
@@ -134,7 +134,7 @@ public class MetadataUpdateServiceTest {
         JsonNode content = ProjectJson.fromTitle("Project with supplementary file").toObjectNode().get("content");
         Project project = new Project(content);
 
-        File supplementaryFile = spy(new File(null, "fileName"));
+        File supplementaryFile = new File(null, "fileName");
         supplementaryFile.setProject(project);
         project.getSupplementaryFiles().add(supplementaryFile);
 

--- a/src/test/java/org/humancellatlas/ingest/core/service/MetadataUpdateServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/MetadataUpdateServiceTest.java
@@ -134,7 +134,7 @@ public class MetadataUpdateServiceTest {
         JsonNode content = ProjectJson.fromTitle("Project with supplementary file").toObjectNode().get("content");
         Project project = new Project(content);
 
-        File supplementaryFile = new File();
+        File supplementaryFile = spy(new File(null, "fileName"));
         supplementaryFile.setProject(project);
         project.getSupplementaryFiles().add(supplementaryFile);
 

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/BiomaterialCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/BiomaterialCrudStrategyTest.java
@@ -26,7 +26,7 @@ public class BiomaterialCrudStrategyTest {
 
     @BeforeEach
     void setUp() {
-        testBiomaterial = new Biomaterial("biomaterialId");
+        testBiomaterial = new Biomaterial(null);
     }
 
     @Test

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/FileCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/FileCrudStrategyTest.java
@@ -32,13 +32,13 @@ public class FileCrudStrategyTest {
 
     @BeforeEach
     void setUp() {
-        testFile = spy(new File(null, "fileName"));
+        testFile = new File(null, "fileName");
     }
 
     @Test
     public void testRemoveLinksFile() {
         //given
-        Project projectWithFile = spy(new Project(null));
+        Project projectWithFile = new Project(null);
         projectWithFile.getSupplementaryFiles().add(testFile);
         when(projectRepository.findBySupplementaryFilesContains(testFile)).thenReturn(Stream.of(projectWithFile));
 

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/FileCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/FileCrudStrategyTest.java
@@ -32,13 +32,13 @@ public class FileCrudStrategyTest {
 
     @BeforeEach
     void setUp() {
-        testFile = new File("fileId");
+        testFile = spy(new File(null, "fileName"));
     }
 
     @Test
     public void testRemoveLinksFile() {
         //given
-        Project projectWithFile = new Project(new Object());
+        Project projectWithFile = spy(new Project(null));
         projectWithFile.getSupplementaryFiles().add(testFile);
         when(projectRepository.findBySupplementaryFilesContains(testFile)).thenReturn(Stream.of(projectWithFile));
 

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProcessCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProcessCrudStrategyTest.java
@@ -35,21 +35,21 @@ public class ProcessCrudStrategyTest {
 
     @BeforeEach
     void setUp() {
-        testProcess = new Process("processId");
+        testProcess = new Process(null);
     }
 
     @Test
     public void testRemoveLinksProcess() {
         //given
-        File inputFile = new File("inputFile");
-        File derivedFile = new File("derivedFile");
+        File inputFile = spy(new File(null, "inputFile"));
+        File derivedFile = spy(new File(null, "derivedFile"));
         inputFile.getInputToProcesses().add(testProcess);
         derivedFile.getDerivedByProcesses().add(testProcess);
         when(fileRepository.findByInputToProcessesContains(testProcess)).thenReturn(Stream.of(inputFile));
         when(fileRepository.findByDerivedByProcessesContains(testProcess)).thenReturn(Stream.of(derivedFile));
 
-        Biomaterial inputBio = new Biomaterial("inputBio");
-        Biomaterial derivedBio = new Biomaterial("derivedBio");
+        Biomaterial inputBio = spy(new Biomaterial(null));
+        Biomaterial derivedBio = spy(new Biomaterial(null));
         inputBio.getInputToProcesses().add(testProcess);
         derivedBio.getDerivedByProcesses().add(testProcess);
         when(biomaterialRepository.findByInputToProcessesContains(testProcess)).thenReturn(Stream.of(inputBio));

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProjectCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProjectCrudStrategyTest.java
@@ -41,7 +41,7 @@ public class ProjectCrudStrategyTest {
 
     @BeforeEach
     void setUp() {
-        testProject = spy(new Project(null));
+        testProject = new Project(null);
     }
 
     @Test

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProjectCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProjectCrudStrategyTest.java
@@ -41,29 +41,29 @@ public class ProjectCrudStrategyTest {
 
     @BeforeEach
     void setUp() {
-        testProject = new Project(new Object());
+        testProject = spy(new Project(null));
     }
 
     @Test
     public void testRemoveLinksProject() {
         // Given
-        Biomaterial biomaterialWithProject = new Biomaterial("biomaterial");
+        Biomaterial biomaterialWithProject = new Biomaterial(null);
         biomaterialWithProject.setProject(testProject);
         biomaterialWithProject.getProjects().add(testProject);
         when(biomaterialRepository.findByProject(testProject)).thenReturn(Stream.of(biomaterialWithProject));
         when(biomaterialRepository.findByProjectsContaining(testProject)).thenReturn(Stream.of(biomaterialWithProject));
 
-        File fileWithProject = new File("file");
+        File fileWithProject = new File(null, "fileWithProject");
         fileWithProject.setProject(testProject);
         when(fileRepository.findByProject(testProject)).thenReturn(Stream.of(fileWithProject));
 
-        Process processWithProject = new Process("process");
+        Process processWithProject = new Process(null);
         processWithProject.setProject(testProject);
         processWithProject.getProjects().add(testProject);
         when(processRepository.findByProject(testProject)).thenReturn(Stream.of(processWithProject));
         when(processRepository.findByProjectsContaining(testProject)).thenReturn(Stream.of(processWithProject));
 
-        Protocol protocolWithProject = new Protocol("protocol");
+        Protocol protocolWithProject = new Protocol(null);
         protocolWithProject.setProject(testProject);
         when(protocolRepository.findByProject(testProject)).thenReturn(Stream.of(protocolWithProject));
 

--- a/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProtocolCrudStrategyTest.java
+++ b/src/test/java/org/humancellatlas/ingest/core/service/strategy/ProtocolCrudStrategyTest.java
@@ -32,13 +32,13 @@ public class ProtocolCrudStrategyTest {
 
     @BeforeEach
     void setUp() {
-        testProtocol = new Protocol("protocolId");
+        testProtocol = new Protocol(null);
     }
 
     @Test
     public void testRemoveLinksProject() {
         // given
-        Process processWithProtocol = new Process("process");
+        Process processWithProtocol = new Process(null);
         processWithProtocol.getProtocols().add(testProtocol);
         when(processRepository.findByProtocolsContains(testProtocol)).thenReturn(Stream.of(processWithProtocol));
 

--- a/src/test/java/org/humancellatlas/ingest/exporter/DefaultExporterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/exporter/DefaultExporterTest.java
@@ -162,7 +162,8 @@ public class DefaultExporterTest {
                 (Answer<Stream<Process>>) invocation -> {
                     List<String> ids = invocation.getArgument(0);
                     return ids.stream().map(id -> {
-                        Process process = new Process(id);
+                        Process process = spy(new Process(null));
+                        doReturn(id).when(process).getId();
                         process.setSubmissionEnvelope(submissionEnvelope);
                         return process;
                     });

--- a/src/test/java/org/humancellatlas/ingest/file/FileTest.java
+++ b/src/test/java/org/humancellatlas/ingest/file/FileTest.java
@@ -16,8 +16,10 @@ public class FileTest {
     @BeforeEach
     void setUp() {
         //given:
+        file = new File(null, "fileName");
+
         process = spy(new Process(null));
-        file = spy(new File(null, "fileName"));
+        doReturn("fe89a0").when(process).getId();
     }
 
     @Test
@@ -31,9 +33,6 @@ public class FileTest {
 
     @Test
     public void testAddDerivedByProcessdNoDuplication() {
-        // given:
-        doReturn("fe89a0").when(process).getId();
-
         // when:
         file.addAsDerivedByProcess(process);
         file.addAsDerivedByProcess(process);

--- a/src/test/java/org/humancellatlas/ingest/file/FileTest.java
+++ b/src/test/java/org/humancellatlas/ingest/file/FileTest.java
@@ -2,6 +2,7 @@ package org.humancellatlas.ingest.file;
 
 import org.humancellatlas.ingest.process.Process;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -9,13 +10,18 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
 public class FileTest {
+    Process process;
+    File file;
+
+    @BeforeEach
+    void setUp() {
+        //given:
+        process = spy(new Process(null));
+        file = spy(new File(null, "fileName"));
+    }
 
     @Test
     public void testAddAsDerivedByProcess() {
-        //given:
-        Process process = createTestProcess();
-        File file = new File();
-
         //when:
         file.addAsDerivedByProcess(process);
 
@@ -25,13 +31,11 @@ public class FileTest {
 
     @Test
     public void testAddDerivedByProcessdNoDuplication() {
-        //given:
-        Process process = createTestProcess();
-        File file = new File();
+        // given:
+        doReturn("fe89a0").when(process).getId();
 
-        //when:
+        // when:
         file.addAsDerivedByProcess(process);
-        //and: add twice
         file.addAsDerivedByProcess(process);
 
         //then:
@@ -41,42 +45,29 @@ public class FileTest {
     @Test
     public void testAddToAnalysis() {
         //given:
-        Process analysis = createTestProcess();
         SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-        analysis.setSubmissionEnvelope(submissionEnvelope);
+        process.setSubmissionEnvelope(submissionEnvelope);
 
         //when:
-        File file = new File();
-        file.addToAnalysis(analysis);
+        file.addToAnalysis(process);
 
         //then:
-        assertThat(file.getDerivedByProcesses()).contains(analysis);
+        assertThat(file.getDerivedByProcesses()).contains(process);
         assertThat(file.getSubmissionEnvelope()).isEqualTo(submissionEnvelope);
     }
 
     @Test
     public void testAddToAnalysisWhenFileAlreadyLinkedToSubmissionEnvelope() {
         //given:
-        Process analysis = createTestProcess();
         SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-        analysis.setSubmissionEnvelope(submissionEnvelope);
-
-        //and:
-        File file = new File();
+        process.setSubmissionEnvelope(submissionEnvelope);
         file.setSubmissionEnvelope(submissionEnvelope);
 
         //when:
-        file.addToAnalysis(analysis);
+        file.addToAnalysis(process);
 
         //then:
-        assertThat(file.getDerivedByProcesses()).contains(analysis);
+        assertThat(file.getDerivedByProcesses()).contains(process);
         assertThat(file.getSubmissionEnvelope()).isEqualTo(submissionEnvelope);
     }
-
-    private Process createTestProcess() {
-        Process process = spy(new Process());
-        doReturn("fe89a0").when(process).getId();
-        return process;
-    }
-
 }

--- a/src/test/java/org/humancellatlas/ingest/messaging/MessageRouterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/messaging/MessageRouterTest.java
@@ -70,7 +70,7 @@ public class MessageRouterTest {
     public void testRouteStateTrackingUpdateMessageFor() {
         // given:
         Project project = mock(Project.class);
-        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope("sub-1");
+        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
         doReturn(Instant.now()).when(project).getUpdateDate();
         doReturn(submissionEnvelope).when(project).getSubmissionEnvelope();
 
@@ -84,7 +84,7 @@ public class MessageRouterTest {
     public void testRouteStateTrackingUpdateMessageForBiomaterial() {
         // given:
         Biomaterial project = mock(Biomaterial.class);
-        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope("sub-1");
+        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
         doReturn(Instant.now()).when(project).getUpdateDate();
         doReturn(submissionEnvelope).when(project).getSubmissionEnvelope();
 
@@ -130,7 +130,8 @@ public class MessageRouterTest {
 
         //and:
         String envelopeId = "87bcf3";
-        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope(envelopeId);
+        SubmissionEnvelope submissionEnvelope = spy(new SubmissionEnvelope());
+        doReturn(envelopeId).when(submissionEnvelope).getId();
         Uuid envelopeUuid = Uuid.newUuid();
         submissionEnvelope.setUuid(envelopeUuid);
 

--- a/src/test/java/org/humancellatlas/ingest/messaging/MessageRouterTest.java
+++ b/src/test/java/org/humancellatlas/ingest/messaging/MessageRouterTest.java
@@ -120,7 +120,9 @@ public class MessageRouterTest {
     private void doTestSendForExport(String routingKey) {
         //given:
         String processId = "78bbd9";
-        Process process = new Process(processId);
+        Process process = spy(new Process(null));
+        doReturn(processId).when(process).getId();
+
         Uuid processUuid = Uuid.newUuid();
         process.setUuid(processUuid);
         Instant version = Instant.now();
@@ -155,7 +157,7 @@ public class MessageRouterTest {
                 .extracting("documentId", "documentUuid", "callbackLink", "documentType",
                         "envelopeId", "envelopeUuid", "index", "total")
                 .containsExactly(processId, processUuid.getUuid().toString(), callbackLink,
-                        Process.class.getSimpleName(), envelopeId, envelopeUuid.getUuid().toString(), 2, 4);
+                    process.getClass().getSimpleName(), envelopeId, envelopeUuid.getUuid().toString(), 2, 4);
     }
 
     @Configuration

--- a/src/test/java/org/humancellatlas/ingest/process/ProcessServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/process/ProcessServiceTest.java
@@ -10,6 +10,7 @@ import org.humancellatlas.ingest.state.MetadataDocumentEventHandler;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.humancellatlas.ingest.submission.SubmissionEnvelopeRepository;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,21 +50,26 @@ public class ProcessServiceTest {
     @MockBean
     private MetadataUpdateService metadataUpdateService;
 
+    String fileName = "ERR1630013.fastq.gz";
+    File file;
+    Process analysis;
+    SubmissionEnvelope submissionEnvelope;
+
+    @BeforeEach
+    void setUp() {
+        // Given:
+        file = spy(new File(null, fileName));
+        analysis = new Process(null);
+        submissionEnvelope = new SubmissionEnvelope();
+        analysis.setSubmissionEnvelope(submissionEnvelope);
+    }
+
     @Test
     public void testAddFileToAnalysisProcess() {
         //given:
-        Process analysis = new Process();
-        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-        analysis.setSubmissionEnvelope(submissionEnvelope);
-
-        //and:
-        File file = new File();
-        file.setFileName("ERR1630013.fastq.gz");
-        file = spy(file);
-
-        //and:
-        doReturn(Collections.emptyList()).when(fileRepository)
-                .findBySubmissionEnvelopeAndFileName(any(SubmissionEnvelope.class), anyString());
+        doReturn(Collections.emptyList())
+            .when(fileRepository)
+            .findBySubmissionEnvelopeAndFileName(any(SubmissionEnvelope.class), anyString());
 
         //when:
         Process result = service.addOutputFileToAnalysisProcess(analysis, file);
@@ -77,18 +83,7 @@ public class ProcessServiceTest {
     @Test
     public void testAddFileToAnalysisProcessWhenFileAlreadyExists() {
         //given:
-        Process analysis = new Process();
-        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-        analysis.setSubmissionEnvelope(submissionEnvelope);
-
-        //and:
-        File file = new File();
-        String fileName = "ERR1630013.fastq.gz";
-        file.setFileName(fileName);
-
-        //and:
-        File persistentFile = spy(new File());
-        List<File> persistentFiles = Arrays.asList(persistentFile);
+        List<File> persistentFiles = Arrays.asList(file);
         doReturn(persistentFiles).when(fileRepository)
                 .findBySubmissionEnvelopeAndFileName(submissionEnvelope, fileName);
 
@@ -99,8 +94,8 @@ public class ProcessServiceTest {
         assertThat(result).isEqualTo(analysis);
 
         //and:
-        verify(persistentFile).addToAnalysis(analysis);
-        verify(fileRepository).save(persistentFile);
+        verify(file).addToAnalysis(analysis);
+        verify(fileRepository).save(file);
     }
 
     @Configuration

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
@@ -90,7 +90,7 @@ public class ProjectServiceTest {
         @DisplayName("get all submissions")
         void getFromAllCopiesOfProjects() {
             //given:
-            var project1 = new Project("project");
+            var project1 = new Project(null);
             var submissionSet1 = IntStream.range(0, 3)
                     .mapToObj(Integer::toString)
                     .map(SubmissionEnvelope::new)
@@ -99,7 +99,7 @@ public class ProjectServiceTest {
             submissionSet1.forEach(project1::addToSubmissionEnvelopes);
 
             //and:
-            var project2 = new Project("project2");
+            var project2 = new Project(null);
             BeanUtils.copyProperties(project1, project2);
             var submissionSet2 = IntStream.range(10, 15)
                     .mapToObj(Integer::toString)
@@ -124,7 +124,7 @@ public class ProjectServiceTest {
         @DisplayName("no duplicate submissions")
         void getFromAllCopiesOfProjectsNoDuplicates() {
             //given:
-            var project1 = new Project("project1");
+            var project1 = new Project(null);
             var submissionSet1 = IntStream.range(0, 3)
                 .mapToObj(Integer::toString)
                 .map(SubmissionEnvelope::new)
@@ -132,7 +132,7 @@ public class ProjectServiceTest {
             submissionSet1.forEach(project1::addToSubmissionEnvelopes);
 
             //and:
-            var project2 = new Project("project2");
+            var project2 = new Project(null);
             BeanUtils.copyProperties(project1, project2);
             var submissionSet2 = IntStream.range(10, 15)
                 .mapToObj(Integer::toString)
@@ -224,14 +224,14 @@ public class ProjectServiceTest {
         @DisplayName("fails for non-empty Project")
         void failForProjectWithSubmissions() {
             //given:
-            var project = new Project("test project");
+            var project = new Project(null);
 
             //and: copy of project with no submissions
-            var persistentEmptyProject = new Project("project");
+            var persistentEmptyProject = new Project(null);
             BeanUtils.copyProperties(project, persistentEmptyProject);
 
             //and: copy of project with submissions
-            var persistentNonEmptyProject = new Project("project");
+            var persistentNonEmptyProject = new Project(null);
             BeanUtils.copyProperties(project, persistentNonEmptyProject);
             IntStream.range(0, 3)
                     .mapToObj(Integer::toString).map(SubmissionEnvelope::new)

--- a/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/project/ProjectServiceTest.java
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.assertj.core.api.Assertions;
 import org.humancellatlas.ingest.bundle.BundleManifestRepository;
+import org.humancellatlas.ingest.core.Uuid;
 import org.humancellatlas.ingest.core.service.MetadataCrudService;
 import org.humancellatlas.ingest.core.service.MetadataUpdateService;
 import org.humancellatlas.ingest.project.exception.NonEmptyProject;
-import org.humancellatlas.ingest.project.web.SearchFilter;
 import org.humancellatlas.ingest.schemas.Schema;
 import org.humancellatlas.ingest.schemas.SchemaService;
 import org.humancellatlas.ingest.submission.SubmissionEnvelope;
@@ -24,8 +24,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.query.Criteria;
-import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.*;
@@ -33,12 +31,9 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toSet;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = {
@@ -85,33 +80,47 @@ public class ProjectServiceTest {
 
     @Nested
     class SubmissionEnvelopes {
+        Project project1;
+        Project project2;
+        Set<SubmissionEnvelope> submissionSet1;
+        Set<SubmissionEnvelope> submissionSet2;
+
+        @BeforeEach
+        void setup(){
+            // given
+            project1 = spy(new Project(null));
+            doReturn("project1").when(project1).getId();
+            project1.setUuid(Uuid.newUuid());
+
+            submissionSet1 = new HashSet<>();
+            IntStream.range(0, 3).mapToObj(Integer::toString).forEach(id -> {
+                var sub = spy(new SubmissionEnvelope());
+                doReturn(id).when(sub).getId();
+                submissionSet1.add(sub);
+            });
+            submissionSet1.forEach(project1::addToSubmissionEnvelopes);
+
+            //and:
+            project2 = spy(new Project(null));
+            doReturn("project2").when(project2).getId();
+            project2.setUuid(project1.getUuid());
+
+            submissionSet2 = new HashSet<>();
+            IntStream.range(10, 15).mapToObj(Integer::toString).forEach(id -> {
+                var sub = spy(new SubmissionEnvelope());
+                doReturn(id).when(sub).getId();
+                submissionSet2.add(sub);
+            });
+            submissionSet2.forEach(project2::addToSubmissionEnvelopes);
+        }
 
         @Test
         @DisplayName("get all submissions")
         void getFromAllCopiesOfProjects() {
-            //given:
-            var project1 = new Project(null);
-            var submissionSet1 = IntStream.range(0, 3)
-                    .mapToObj(Integer::toString)
-                    .map(SubmissionEnvelope::new)
-                    .collect(toSet());
+            // given
+            when(projectRepository.findByUuid(project1.getUuid())).thenReturn(Stream.of(project1, project2));
 
-            submissionSet1.forEach(project1::addToSubmissionEnvelopes);
-
-            //and:
-            var project2 = new Project(null);
-            BeanUtils.copyProperties(project1, project2);
-            var submissionSet2 = IntStream.range(10, 15)
-                    .mapToObj(Integer::toString)
-                    .map(SubmissionEnvelope::new)
-                    .collect(toSet());
-            submissionSet2.forEach(project2::addToSubmissionEnvelopes);
-
-            //and:
-            doReturn(Stream.of(project1, project2))
-                    .when(projectRepository).findByUuid(project1.getUuid());
-
-            //when:
+            // when:
             var submissionEnvelopes = projectService.getSubmissionEnvelopes(project1);
 
             //then:
@@ -123,45 +132,28 @@ public class ProjectServiceTest {
         @Test
         @DisplayName("no duplicate submissions")
         void getFromAllCopiesOfProjectsNoDuplicates() {
-            //given:
-            var project1 = new Project(null);
-            var submissionSet1 = IntStream.range(0, 3)
-                .mapToObj(Integer::toString)
-                .map(SubmissionEnvelope::new)
-                .collect(toSet());
-            submissionSet1.forEach(project1::addToSubmissionEnvelopes);
+            // given
+            var project3 = spy(new Project(null));
+            doReturn("project3").when(project3).getId();
+            project3.setUuid(project1.getUuid());
 
-            //and:
-            var project2 = new Project(null);
-            BeanUtils.copyProperties(project1, project2);
-            var submissionSet2 = IntStream.range(10, 15)
-                .mapToObj(Integer::toString)
-                .map(SubmissionEnvelope::new)
-                .collect(toSet());
-            submissionSet2.forEach(project2::addToSubmissionEnvelopes);
-
-            var project3 = new Project(null);
-            BeanUtils.copyProperties(project1, project3);
-            submissionSet1.forEach(submission ->
-                project3.addToSubmissionEnvelopes(new SubmissionEnvelope(submission.getId()))
-            );
+            submissionSet1.forEach(project3::addToSubmissionEnvelopes);
 
             var documentIds = new ArrayList<String>();
             submissionSet1.forEach(submission -> documentIds.add(submission.getId()));
             submissionSet2.forEach(submission -> documentIds.add(submission.getId()));
 
             //and:
-            doReturn(Stream.of(project1, project2, project3))
-                .when(projectRepository).findByUuid(project1.getUuid());
+            when(projectRepository.findByUuid(project1.getUuid())).thenReturn(Stream.of(project1, project2, project3));
 
             //when:
             var submissionEnvelopes = projectService.getSubmissionEnvelopes(project1);
+
+            //then:
             var returnDocumentIds = new ArrayList<String>();
             submissionEnvelopes.forEach(submission -> returnDocumentIds.add(submission.getId()));
 
-            //then:
-            assertThat(returnDocumentIds)
-                .containsExactlyInAnyOrderElementsOf(documentIds);
+            assertThat(returnDocumentIds).containsExactlyInAnyOrderElementsOf(documentIds);
         }
 
     }
@@ -234,8 +226,12 @@ public class ProjectServiceTest {
             var persistentNonEmptyProject = new Project(null);
             BeanUtils.copyProperties(project, persistentNonEmptyProject);
             IntStream.range(0, 3)
-                    .mapToObj(Integer::toString).map(SubmissionEnvelope::new)
-                    .forEach(persistentNonEmptyProject::addToSubmissionEnvelopes);
+                    .mapToObj(Integer::toString)
+                    .forEach(id -> {
+                        SubmissionEnvelope sub = spy(new SubmissionEnvelope());
+                        doReturn(id).when(sub).getId();
+                        persistentNonEmptyProject.addToSubmissionEnvelopes(sub);
+                    });
 
             //and:
             doReturn(Stream.of(persistentEmptyProject, persistentNonEmptyProject))

--- a/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
@@ -49,7 +49,7 @@ public class ProtocolServiceTest {
         @Test
         void determineLinking() {
             //given:
-            SubmissionEnvelope submission = new SubmissionEnvelope("89bcba7");
+            SubmissionEnvelope submission = new SubmissionEnvelope();
 
             //and:
             Protocol linked = new Protocol("linked");

--- a/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/protocol/ProtocolServiceTest.java
@@ -59,7 +59,7 @@ public class ProtocolServiceTest {
                     .findBySubmissionEnvelope(submission, pageable);
 
             //and:
-            doReturn(Optional.of(new Process())).when(processRepository).findFirstByProtocolsContains(linked);
+            doReturn(Optional.of(new Process(null))).when(processRepository).findFirstByProtocolsContains(linked);
             doReturn(Optional.empty()).when(processRepository).findFirstByProtocolsContains(notLinked);
 
             //when:

--- a/src/test/java/org/humancellatlas/ingest/state/MetadataDocumentEventHandlerTest.java
+++ b/src/test/java/org/humancellatlas/ingest/state/MetadataDocumentEventHandlerTest.java
@@ -26,7 +26,7 @@ public class MetadataDocumentEventHandlerTest {
     @Test
     public void testHandleCreateDocumentsWithSubmissionEnvelope() {
         Project project = new Project(null);
-        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope("sub-1");
+        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
         project.setSubmissionEnvelope(submissionEnvelope);
         handler.handleMetadataDocumentCreate(project);
         Mockito.verify(messageRouter, times(1)).routeValidationMessageFor(project);

--- a/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
@@ -105,25 +105,6 @@ public class SubmissionEnvelopeServiceTest {
     static class TestConfiguration {
     }
 
-    static class TestProject extends Project {
-        Set<File> supplementaryFiles;
-
-        TestProject(Object content) {
-            super(content);
-            supplementaryFiles = super.getSupplementaryFiles();
-        }
-
-        @Override
-        public Set<File> getSupplementaryFiles() {
-            return supplementaryFiles;
-        }
-
-        public void addToSupplementaryFiles(File file) {
-            supplementaryFiles.add(file);
-        }
-    }
-
-
     @Test
     public void testDeleteSubmission() {
         //given SubmissionEnvelope
@@ -150,12 +131,11 @@ public class SubmissionEnvelopeServiceTest {
         testOutsideProcess.getProtocols().add(testProtocol);
 
         //given File
-        File file = new File();
-        file.setFileName("testFile.txt");
+        File file = new File(null, "testFile.txt");
         file.setSubmissionEnvelope(submissionEnvelope);
 
         //given Project
-        TestProject project = new TestProject(new Object());
+        Project project = new Project(new Object());
         project.setUuid(Uuid.newUuid());
         project.setSubmissionEnvelope(submissionEnvelope);
         project.addToSubmissionEnvelopes(submissionEnvelope);
@@ -163,7 +143,7 @@ public class SubmissionEnvelopeServiceTest {
         assertThat(project.getSubmissionEnvelope()).isEqualTo(submissionEnvelope);
 
         //given SupplementaryFile
-        project.addToSupplementaryFiles(file);
+        project.getSupplementaryFiles().add(file);
         assertThat(project.getSupplementaryFiles()).contains(file);
 
         //given ProjectRepository
@@ -259,8 +239,7 @@ public class SubmissionEnvelopeServiceTest {
             Biomaterial testBiomaterial = new Biomaterial(Map.ofEntries(Map.entry("key", UUID.randomUUID())));
             Protocol testProtocol = new Protocol(Map.ofEntries(Map.entry("key", UUID.randomUUID())));
             Process testProcess = new Process(Map.ofEntries(Map.entry("key", UUID.randomUUID())));
-            File testFile = new File();
-            testFile.setFileName("testFile.txt");
+            File testFile = new File(null, "testFile.txt");
 
             testProcess.setSubmissionEnvelope(submissionEnvelope);
             testProtocol.setSubmissionEnvelope(submissionEnvelope);


### PR DESCRIPTION
### Changes
- [x] Move the [ProjectFilterTest.java](src/integration/java/org/humancellatlas/ingest/project/ProjectFilterTest.java) from unit tests to integration tests, since it cannot pass without a mongo connection.
    - This has been confirmed to be a configuration issue, but the in-memory mongo that the integration tests use does take a lot longer to complete than the usual unit tests. 
- [x] Ensure any integration tests that use real repositories clean up any data they add into the repository after each test.
    - BiomaterialControllerTest.java
    - FileControllerTest.java
    - ProcessControllerTest.java
    - ProcessRepositoryTest.java
    - ProjectControllerTest.java
    - StagingJobRepositoryTest.java
    - SubmissionLinkMapControllerTest.java
- [x] Change integration tests to all use in-memory mongo
- [x] Remove constructors only used by test class from real classes:
    - Biomaterial
    - File
    - Process
    - Protocol
    - Project
    - SubmissionEnvelope 