### PR TITLE
Allow adding but not editing for some endpoints

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/web/BiomaterialController.java
@@ -67,7 +67,7 @@ public class BiomaterialController {
     private @Autowired
     MetadataLinkingService metadataLinkingService;
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "submissionEnvelopes/{sub_id}/biomaterials", method = RequestMethod.POST)
     ResponseEntity<Resource<?>> addBiomaterialToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                                          @RequestBody Biomaterial biomaterial,
@@ -82,7 +82,7 @@ public class BiomaterialController {
         return ResponseEntity.accepted().body(resource);
     }
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "submissionEnvelopes/{sub_id}/biomaterials/{id}", method = RequestMethod.PUT)
     ResponseEntity<Resource<?>> linkBiomaterialToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                                           @PathVariable("id") Biomaterial biomaterial,
@@ -104,7 +104,7 @@ public class BiomaterialController {
         return ResponseEntity.accepted().body(resource);
     }
 
-    @CheckAllowed(value = "#biomaterial.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#biomaterial.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/biomaterials/{id}/inputToProcesses", method = {PUT, POST}, consumes = {TEXT_URI_LIST_VALUE})
     HttpEntity<?> linkBiomaterialAsInputToProcesses(@PathVariable("id") Biomaterial biomaterial,
                                                     @RequestBody Resources<Object> incoming,
@@ -117,7 +117,7 @@ public class BiomaterialController {
         return ResponseEntity.ok().build();
     }
 
-    @CheckAllowed(value = "#biomaterial.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#biomaterial.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/biomaterials/{id}/derivedByProcesses", method = {PUT, POST}, consumes = {TEXT_URI_LIST_VALUE})
     HttpEntity<?> linkBiomaterialAsDerivedByProcesses(@PathVariable("id") Biomaterial biomaterial,
                                                       @RequestBody Resources<Object> incoming,

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileController.java
@@ -73,7 +73,7 @@ public class FileController {
     private @Autowired
     MetadataLinkingService metadataLinkingService;
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/submissionEnvelopes/{sub_id}/files",
             method = RequestMethod.POST,
             produces = MediaTypes.HAL_JSON_VALUE)
@@ -111,7 +111,7 @@ public class FileController {
         return ResponseEntity.accepted().body(resource);
     }
 
-    @CheckAllowed(value = "#file.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#file.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/files/{id}/inputToProcesses", method = {PUT, POST}, consumes = {TEXT_URI_LIST_VALUE})
     HttpEntity<?> linkFileAsInputToProcesses(@PathVariable("id") File file,
                                              @RequestBody Resources<Object> incoming,
@@ -124,7 +124,7 @@ public class FileController {
         return ResponseEntity.ok().build();
     }
 
-    @CheckAllowed(value = "#file.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#file.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/files/{id}/derivedByProcesses", method = {PUT, POST}, consumes = {TEXT_URI_LIST_VALUE})
     HttpEntity<?> linkFileAsDerivedByProcesses(@PathVariable("id") File file,
                                                @RequestBody Resources<Object> incoming,

--- a/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
+++ b/src/main/java/org/humancellatlas/ingest/process/web/ProcessController.java
@@ -97,7 +97,7 @@ public class ProcessController {
     }
 
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "submissionEnvelopes/{sub_id}/processes", method = RequestMethod.POST)
     ResponseEntity<Resource<?>> addProcessToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                                      @RequestBody Process process,
@@ -112,7 +112,7 @@ public class ProcessController {
         return ResponseEntity.accepted().body(resource);
     }
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "submissionEnvelopes/{sub_id}/processes/{id}", method = RequestMethod.PUT)
     ResponseEntity<Resource<?>> linkProcessToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                                       @PathVariable("id") Process process,
@@ -128,7 +128,7 @@ public class ProcessController {
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
     }
 
-    @CheckAllowed(value = "#analysis.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#analysis.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/processes/{analysis_id}/" + Links.BUNDLE_REF_URL,
             method = RequestMethod.PUT)
     ResponseEntity<Resource<?>> oldAddBundleReference(@PathVariable("analysis_id") Process analysis,
@@ -139,7 +139,7 @@ public class ProcessController {
         return ResponseEntity.accepted().body(resource);
     }
 
-    @CheckAllowed(value = "#analysis.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#analysis.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/processes/{analysis_id}/" + Links.BUNDLE_REF_URL,
             method = RequestMethod.POST)
     ResponseEntity<Resource<?>> addBundleReference(@PathVariable("analysis_id") Process analysis,
@@ -155,7 +155,7 @@ public class ProcessController {
         return ResponseEntity.status(HttpStatus.METHOD_NOT_ALLOWED).build();
     }
 
-    @CheckAllowed(value = "#analysis.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#analysis.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/processes/{analysis_id}/" + Links.FILE_REF_URL,
             method = RequestMethod.PUT)
     ResponseEntity<Resource<?>> addOutputFileReference(@PathVariable("analysis_id") Process analysis,
@@ -166,7 +166,7 @@ public class ProcessController {
         return ResponseEntity.accepted().body(resource);
     }
 
-    @CheckAllowed(value = "#analysis.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#analysis.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/processes/{analysis_id}/" + Links.INPUT_FILES_URL,
             method = RequestMethod.POST)
     ResponseEntity<Resource<?>> addInputFileReference(@PathVariable("analysis_id") Process analysis,
@@ -197,7 +197,7 @@ public class ProcessController {
         return ResponseEntity.accepted().body(resource);
     }
 
-    @CheckAllowed(value = "#process.submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#process.submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/processes/{id}/protocols", method = {PUT, POST}, consumes = {TEXT_URI_LIST_VALUE})
     HttpEntity<?> linkProtocolsToProcess(@PathVariable("id") Process process,
                                          @RequestBody Resources<Object> incoming,

--- a/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
+++ b/src/main/java/org/humancellatlas/ingest/project/web/ProjectController.java
@@ -118,7 +118,7 @@ public class ProjectController {
         return ResponseEntity.ok().body(assembler.toFullResource(updatedProject));
     }
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @PostMapping(path = "submissionEnvelopes/{sub_id}/projects")
     ResponseEntity<Resource<?>> addProjectToEnvelope(
             @PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
@@ -185,7 +185,7 @@ public class ProjectController {
         return ResponseEntity.ok(getPagedResourcesAssembler().toResource(files, resourceAssembler));
     }
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @PutMapping(path = "projects/{proj_id}/submissionEnvelopes/{sub_id}")
     ResponseEntity<Resource<?>> linkSubmissionToProject(
             @PathVariable("proj_id") Project project,

--- a/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/web/ProtocolController.java
@@ -49,7 +49,7 @@ public class ProtocolController {
     private final @NonNull MetadataCrudService metadataCrudService;
     private final @NonNull MetadataUpdateService metadataUpdateService;
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/submissionEnvelopes/{sub_id}/protocols", method = RequestMethod.POST)
     ResponseEntity<Resource<?>> addProtocolToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                                       @RequestBody Protocol protocol,
@@ -64,7 +64,7 @@ public class ProtocolController {
         return ResponseEntity.accepted().body(resource);
     }
 
-    @CheckAllowed(value = "#submissionEnvelope.isEditable()", exception = NotAllowedDuringSubmissionStateException.class)
+    @CheckAllowed(value = "#submissionEnvelope.canAddTo()", exception = NotAllowedDuringSubmissionStateException.class)
     @RequestMapping(path = "/submissionEnvelopes/{sub_id}/protocols/{protocol_id}", method = RequestMethod.PUT)
     ResponseEntity<Resource<?>> linkProtocolToEnvelope(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                                        @PathVariable("id") Protocol protocol,

--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelope.java
@@ -129,8 +129,10 @@ public class SubmissionEnvelope extends AbstractEntity {
         return states.indexOf(this.getSubmissionState()) < states.indexOf(SubmissionState.SUBMITTED);
     }
 
-    public boolean isEditable() {
-        List<SubmissionState> nonEditableStates = Arrays.asList(
+    private List<SubmissionState> getNonEditableStates() {
+        return Arrays.asList(
+                SubmissionState.PENDING,
+                SubmissionState.METADATA_VALIDATING,
                 SubmissionState.GRAPH_VALIDATION_REQUESTED,
                 SubmissionState.GRAPH_VALIDATING,
                 SubmissionState.EXPORTING,
@@ -139,7 +141,18 @@ public class SubmissionEnvelope extends AbstractEntity {
                 SubmissionState.ARCHIVED,
                 SubmissionState.SUBMITTED
         );
+    }
 
-        return !nonEditableStates.contains(this.submissionState);
+    public boolean isEditable() {
+        return !this.getNonEditableStates().contains(this.submissionState);
+    }
+
+    public boolean canAddTo () {
+        // The importer has to add metadata and perform linking while the submission may be in METADATA_VALIDATING
+        // So, this is used for the special case of allowing the importer to function
+        return this.getNonEditableStates().stream()
+                .filter(state -> state != SubmissionState.PENDING)
+                .filter(state -> state != SubmissionState.METADATA_VALIDATING)
+                .noneMatch(state -> state == this.submissionState);
     }
 }

--- a/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeTest.java
@@ -113,6 +113,8 @@ public class SubmissionEnvelopeTest {
     @Test
     public void testIsEditable() {
         Arrays.asList(
+                SubmissionState.PENDING,
+                SubmissionState.METADATA_VALIDATING,
                 SubmissionState.GRAPH_VALIDATION_REQUESTED,
                 SubmissionState.GRAPH_VALIDATING,
                 SubmissionState.EXPORTING,
@@ -131,11 +133,6 @@ public class SubmissionEnvelopeTest {
         });
 
         Arrays.asList(
-                SubmissionState.PENDING,
-                // METADATA_VALIDATING should not be allowed but it's needed at the moment because of the way
-                // spreadsheet importing works. Submissions flip rapidly between pending and validating during
-                // import.
-                SubmissionState.METADATA_VALIDATING,
                 SubmissionState.METADATA_VALID,
                 SubmissionState.METADATA_INVALID,
                 SubmissionState.EXPORTED,
@@ -152,6 +149,48 @@ public class SubmissionEnvelopeTest {
 
             //then:
             assertThat(submissionEnvelope.isEditable()).isTrue();
+        });
+    }
+
+    @Test
+    public void testCanAddTo() {
+        Arrays.asList(
+                SubmissionState.GRAPH_VALIDATION_REQUESTED,
+                SubmissionState.GRAPH_VALIDATING,
+                SubmissionState.EXPORTING,
+                SubmissionState.PROCESSING,
+                SubmissionState.CLEANUP,
+                SubmissionState.ARCHIVED,
+                SubmissionState.SUBMITTED
+        ).forEach(state -> {
+            //given:
+            SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
+            submissionEnvelope.enactStateTransition(state);
+            assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
+
+            //then:
+            assertThat(submissionEnvelope.canAddTo()).isFalse();
+        });
+
+        Arrays.asList(
+                SubmissionState.METADATA_VALIDATING,
+                SubmissionState.PENDING,
+                SubmissionState.METADATA_VALID,
+                SubmissionState.METADATA_INVALID,
+                SubmissionState.EXPORTED,
+                SubmissionState.GRAPH_VALID,
+                SubmissionState.GRAPH_INVALID,
+                SubmissionState.COMPLETE,
+                SubmissionState.DRAFT,
+                SubmissionState.ARCHIVING
+        ).forEach(state -> {
+            //given:
+            SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
+            submissionEnvelope.enactStateTransition(state);
+            assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
+
+            //then:
+            assertThat(submissionEnvelope.canAddTo()).isTrue();
         });
     }
 

--- a/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeTest.java
@@ -3,12 +3,12 @@ package org.humancellatlas.ingest.submission;
 
 import org.humancellatlas.ingest.state.SubmissionState;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
-import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 public class SubmissionEnvelopeTest {
 
@@ -110,88 +110,90 @@ public class SubmissionEnvelopeTest {
     }
 
 
-    @Test
-    public void testIsEditable() {
-        Arrays.asList(
-                SubmissionState.PENDING,
-                SubmissionState.METADATA_VALIDATING,
-                SubmissionState.GRAPH_VALIDATION_REQUESTED,
-                SubmissionState.GRAPH_VALIDATING,
-                SubmissionState.EXPORTING,
-                SubmissionState.PROCESSING,
-                SubmissionState.CLEANUP,
-                SubmissionState.ARCHIVED,
-                SubmissionState.SUBMITTED
-        ).forEach(state -> {
-            //given:
-            SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-            submissionEnvelope.enactStateTransition(state);
-            assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
+    @ParameterizedTest
+    @EnumSource(value = SubmissionState.class, names = {
+        "PENDING",
+        "METADATA_VALIDATING",
+        "GRAPH_VALIDATION_REQUESTED",
+        "GRAPH_VALIDATING",
+        "EXPORTING",
+        "PROCESSING",
+        "CLEANUP",
+        "ARCHIVED",
+        "SUBMITTED"
+    })
+    public void testIsNotEditable(SubmissionState state) {
+        //given:
+        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
+        submissionEnvelope.enactStateTransition(state);
+        assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
 
-            //then:
-            assertThat(submissionEnvelope.isEditable()).isFalse();
-        });
-
-        Arrays.asList(
-                SubmissionState.METADATA_VALID,
-                SubmissionState.METADATA_INVALID,
-                SubmissionState.EXPORTED,
-                SubmissionState.GRAPH_VALID,
-                SubmissionState.GRAPH_INVALID,
-                SubmissionState.COMPLETE,
-                SubmissionState.DRAFT,
-                SubmissionState.ARCHIVING
-        ).forEach(state -> {
-            //given:
-            SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-            submissionEnvelope.enactStateTransition(state);
-            assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
-
-            //then:
-            assertThat(submissionEnvelope.isEditable()).isTrue();
-        });
+        //then:
+        assertThat(submissionEnvelope.isEditable()).isFalse();
     }
 
-    @Test
-    public void testCanAddTo() {
-        Arrays.asList(
-                SubmissionState.GRAPH_VALIDATION_REQUESTED,
-                SubmissionState.GRAPH_VALIDATING,
-                SubmissionState.EXPORTING,
-                SubmissionState.PROCESSING,
-                SubmissionState.CLEANUP,
-                SubmissionState.ARCHIVED,
-                SubmissionState.SUBMITTED
-        ).forEach(state -> {
-            //given:
-            SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-            submissionEnvelope.enactStateTransition(state);
-            assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
+    @ParameterizedTest
+    @EnumSource(value = SubmissionState.class, names = {
+        "METADATA_VALID",
+        "METADATA_INVALID",
+        "EXPORTED",
+        "GRAPH_VALID",
+        "GRAPH_INVALID",
+        "COMPLETE",
+        "DRAFT",
+        "ARCHIVING"
+    })
+    public void testIsEditable(SubmissionState state) {
+        //given:
+        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
+        submissionEnvelope.enactStateTransition(state);
+        assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
 
-            //then:
-            assertThat(submissionEnvelope.canAddTo()).isFalse();
-        });
+        //then:
+        assertThat(submissionEnvelope.isEditable()).isTrue();
+    }
 
-        Arrays.asList(
-                SubmissionState.METADATA_VALIDATING,
-                SubmissionState.PENDING,
-                SubmissionState.METADATA_VALID,
-                SubmissionState.METADATA_INVALID,
-                SubmissionState.EXPORTED,
-                SubmissionState.GRAPH_VALID,
-                SubmissionState.GRAPH_INVALID,
-                SubmissionState.COMPLETE,
-                SubmissionState.DRAFT,
-                SubmissionState.ARCHIVING
-        ).forEach(state -> {
-            //given:
-            SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-            submissionEnvelope.enactStateTransition(state);
-            assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
+    @ParameterizedTest
+    @EnumSource(value = SubmissionState.class, names = {
+        "GRAPH_VALIDATION_REQUESTED",
+        "GRAPH_VALIDATING",
+        "EXPORTING",
+        "PROCESSING",
+        "CLEANUP",
+        "ARCHIVED",
+        "SUBMITTED"
+    })
+    public void testCannotAddTo(SubmissionState state) {
+        //given:
+        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
+        submissionEnvelope.enactStateTransition(state);
+        assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
 
-            //then:
-            assertThat(submissionEnvelope.canAddTo()).isTrue();
-        });
+        //then:
+        assertThat(submissionEnvelope.canAddTo()).isFalse();
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = SubmissionState.class, names = {
+        "METADATA_VALIDATING",
+        "PENDING",
+        "METADATA_VALID",
+        "METADATA_INVALID",
+        "EXPORTED",
+        "GRAPH_VALID",
+        "GRAPH_INVALID",
+        "COMPLETE",
+        "DRAFT",
+        "ARCHIVING"
+    })
+    public void testCanAddTo(SubmissionState state) {
+        //given:
+        SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
+        submissionEnvelope.enactStateTransition(state);
+        assertThat(submissionEnvelope.getSubmissionState()).isEqualTo(state);
+
+        //then:
+        assertThat(submissionEnvelope.canAddTo()).isTrue();
     }
 
     private List<SubmissionState> getAllowedStates(SubmissionState state) {


### PR DESCRIPTION
dcp-752

Allows importer to continue importing while submission is in PENDING or METADATA_VALID.

**Please Check**
- All endpoints that are used by importing have been changed
- No extra endpoints that aren't used by importing have been changed