### PR TITLE
dcp-812 Submission Envelopes shared implementation for Projects & Related Projects

### DIFF
--- a/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionControllerTest.java
@@ -174,7 +174,7 @@ public class SubmissionControllerTest {
         "/submissionEnvelopes/{id}/projects",
         "/submissionEnvelopes/{id}/relatedProjects"
     })
-    public void testProjectsAreReturnedWHenTheyIncludeTheSubmissionEnvelope(String endpoint) throws Exception {
+    public void testProjectsAreReturnedWhenTheyIncludeTheSubmissionInTheirEnvelopes(String endpoint) throws Exception {
         webApp.perform(
             // when
             get(endpoint, submissionEnvelope.getId())

--- a/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionControllerTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/submission/web/SubmissionControllerTest.java
@@ -32,7 +32,11 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
@@ -91,7 +95,6 @@ public class SubmissionControllerTest {
         submissionEnvelope = submissionEnvelopeRepository.save(submissionEnvelope);
 
         project = new Project(null);
-        project.setSubmissionEnvelope(submissionEnvelope);
         project.getSubmissionEnvelopes().add(submissionEnvelope);
         project = projectRepository.save(project);
 
@@ -164,5 +167,21 @@ public class SubmissionControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("{\"content\": {}}")
         ).andExpect(status().isForbidden());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "/submissionEnvelopes/{id}/projects",
+        "/submissionEnvelopes/{id}/relatedProjects"
+    })
+    public void testProjectsAreReturnedWHenTheyIncludeTheSubmissionEnvelope(String endpoint) throws Exception {
+        webApp.perform(
+            // when
+            get(endpoint, submissionEnvelope.getId())
+                .contentType(MediaType.APPLICATION_JSON)
+        )   // then
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$._embedded.projects", hasSize(1)))
+            .andExpect(jsonPath("$._embedded.projects[0].uuid.uuid", is(project.getUuid().getUuid().toString())));
     }
 }

--- a/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
+++ b/src/main/java/org/humancellatlas/ingest/project/ProjectRepository.java
@@ -41,8 +41,6 @@ public interface ProjectRepository extends MongoRepository<Project, String> {
                                                 @Param(value = "primaryWrangler") String primaryWrangler, 
                                                 Pageable pageable);
 
-    Page<Project> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
-
     Page<Project> findBySubmissionEnvelopesContaining(SubmissionEnvelope submissionEnvelope, Pageable pageable);
 
     @RestResource(exported = false)

--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeService.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeService.java
@@ -311,7 +311,7 @@ public class SubmissionEnvelopeService {
 
     public Optional<Instant> getSubmissionContentLastUpdated(SubmissionEnvelope submissionEnvelope) {
         PageRequest request = PageRequest.of(0, 1, new Sort(Sort.Direction.DESC, "updateDate"));
-        List<Project> projects = projectRepository.findBySubmissionEnvelope(submissionEnvelope, request).getContent();
+        List<Project> projects = projectRepository.findBySubmissionEnvelopesContaining(submissionEnvelope, request).getContent();
         List<Biomaterial> biomaterials = biomaterialRepository.findBySubmissionEnvelope(submissionEnvelope, request).getContent();
         List<Protocol> protocols = protocolRepository.findBySubmissionEnvelope(submissionEnvelope, request).getContent();
         List<Process> processes = processRepository.findBySubmissionEnvelope(submissionEnvelope, request).getContent();

--- a/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeService.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeService.java
@@ -324,4 +324,8 @@ public class SubmissionEnvelopeService {
 
         return optionalLastUpdateDate;
     }
+
+    public Optional<Project> getProject(SubmissionEnvelope submissionEnvelope) {
+        return projectRepository.findBySubmissionEnvelopesContains(submissionEnvelope).findFirst();
+    }
 }

--- a/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
+++ b/src/main/java/org/humancellatlas/ingest/submission/web/SubmissionController.java
@@ -89,18 +89,13 @@ public class SubmissionController {
         return ResponseEntity.ok(resourceAssembler.toFullResource(updateSubmission));
     }
 
-    @GetMapping("/submissionEnvelopes/{sub_id}/projects")
+    @GetMapping({
+        "/submissionEnvelopes/{sub_id}" + Links.PROJECTS_URL,
+        "/submissionEnvelopes/{sub_id}" + Links.SUBMISSION_RELATED_PROJECTS_URL
+    })
     ResponseEntity<?> getProjects(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
                                   Pageable pageable,
                                   final PersistentEntityResourceAssembler resourceAssembler) {
-        Page<Project> projects = getProjectRepository().findBySubmissionEnvelope(submissionEnvelope, pageable);
-        return ResponseEntity.ok(getPagedResourcesAssembler().toResource(projects, resourceAssembler));
-    }
-
-    @GetMapping("/submissionEnvelopes/{sub_id}" + Links.SUBMISSION_RELATED_PROJECTS_URL)
-    ResponseEntity<?> getRelatedProjects(@PathVariable("sub_id") SubmissionEnvelope submissionEnvelope,
-                                         Pageable pageable,
-                                         final PersistentEntityResourceAssembler resourceAssembler) {
         Page<Project> projects = getProjectRepository().findBySubmissionEnvelopesContaining(submissionEnvelope, pageable);
         return ResponseEntity.ok(getPagedResourcesAssembler().toResource(projects, resourceAssembler));
     }

--- a/src/test/java/org/humancellatlas/ingest/state/MetadataDocumentEventHandlerTest.java
+++ b/src/test/java/org/humancellatlas/ingest/state/MetadataDocumentEventHandlerTest.java
@@ -27,7 +27,7 @@ public class MetadataDocumentEventHandlerTest {
     public void testHandleCreateDocumentsWithSubmissionEnvelope() {
         Project project = new Project(null);
         SubmissionEnvelope submissionEnvelope = new SubmissionEnvelope();
-        project.setSubmissionEnvelope(submissionEnvelope);
+        project.getSubmissionEnvelopes().add(submissionEnvelope);
         handler.handleMetadataDocumentCreate(project);
         Mockito.verify(messageRouter, times(1)).routeValidationMessageFor(project);
         Mockito.verify(messageRouter, times(1)).routeStateTrackingUpdateMessageFor(project);

--- a/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
@@ -139,7 +139,6 @@ public class SubmissionEnvelopeServiceTest {
         project.setUuid(Uuid.newUuid());
         project.addToSubmissionEnvelopes(submissionEnvelope);
         assertThat(project.getSubmissionEnvelopes()).contains(submissionEnvelope);
-        assertThat(project.getSubmissionEnvelope()).isEqualTo(submissionEnvelope);
 
         //given SupplementaryFile
         project.getSupplementaryFiles().add(file);

--- a/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
@@ -147,7 +147,7 @@ public class SubmissionEnvelopeServiceTest {
         //given ProjectRepository
         List<Project> projectList = new ArrayList<>();
         projectList.add(project);
-        when(projectRepository.findBySubmissionEnvelope(any(), any()))
+        when(projectRepository.findBySubmissionEnvelopesContaining(any(), any()))
                 .thenReturn(new PageImpl<>(projectList, Pageable.unpaged(), 1));
 
         when(projectRepository.findBySubmissionEnvelopesContains(any()))
@@ -182,7 +182,7 @@ public class SubmissionEnvelopeServiceTest {
         verify(submissionManifestRepository).deleteBySubmissionEnvelope(submissionEnvelope);
         verify(submissionErrorRepository).deleteBySubmissionEnvelope(submissionEnvelope);
 
-        verify(projectRepository).findBySubmissionEnvelope(submissionEnvelope);
+        verify(projectRepository).findBySubmissionEnvelopesContains(submissionEnvelope);
         assertThat(project.getSubmissionEnvelopes()).isEmpty();
         verify(projectRepository, atLeastOnce()).save(project);
         verify(submissionEnvelopeRepository).delete(submissionEnvelope);
@@ -315,7 +315,7 @@ public class SubmissionEnvelopeServiceTest {
         File file =  mock(File.class);
 
         PageRequest request = PageRequest.of(0, 1, new Sort(Sort.Direction.DESC, "updateDate"));
-        when(projectRepository.findBySubmissionEnvelope(submission, request))
+        when(projectRepository.findBySubmissionEnvelopesContaining(submission, request))
                 .thenReturn(new PageImpl<>(List.of(project), request, 1));
         when(protocolRepository.findBySubmissionEnvelope(submission, request))
                 .thenReturn(Page.empty());
@@ -347,7 +347,7 @@ public class SubmissionEnvelopeServiceTest {
         SubmissionEnvelope submission = mock(SubmissionEnvelope.class);
 
         PageRequest request = PageRequest.of(0, 1, new Sort(Sort.Direction.DESC, "updateDate"));
-        when(projectRepository.findBySubmissionEnvelope(submission, request))
+        when(projectRepository.findBySubmissionEnvelopesContaining(submission, request))
                 .thenReturn(Page.empty());
         when(protocolRepository.findBySubmissionEnvelope(submission, request))
                 .thenReturn(Page.empty());

--- a/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
+++ b/src/test/java/org/humancellatlas/ingest/submission/SubmissionEnvelopeServiceTest.java
@@ -137,7 +137,6 @@ public class SubmissionEnvelopeServiceTest {
         //given Project
         Project project = new Project(new Object());
         project.setUuid(Uuid.newUuid());
-        project.setSubmissionEnvelope(submissionEnvelope);
         project.addToSubmissionEnvelopes(submissionEnvelope);
         assertThat(project.getSubmissionEnvelopes()).contains(submissionEnvelope);
         assertThat(project.getSubmissionEnvelope()).isEqualTo(submissionEnvelope);


### PR DESCRIPTION
GitHub: ebi-ait/dcp-ingest-central#812
ZenHub: dcp-812

- [x] make `submissionEnvelopes/{id}/projects` return the same results as `submissionEnvelopes/{id}/relatedProjects`
    - `/relatedProjects` is: "The projects this submission envelope has been added to" 
    - `/projects` used to mean "The projects created by this submission envelope.
- [x] remove incorrect projectRepository.findBySubmissionEnvelope method
    - The `project.SubmissionEnvelope` attribute is the submission envelope that created the project, which is often irrelevant as projects can now be disconnected from submissionEnvelopes.