### PR TITLE
dcp-845 Increase Timeout & Re-queue

### DIFF
--- a/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
+++ b/src/integration/java/org/humancellatlas/ingest/file/FileServiceTest.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import java.util.stream.Stream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -147,6 +148,21 @@ public class FileServiceTest {
 
         //then:
         verify(fileRepository, times(2)).save(file);
+    }
+
+    @Test
+    public void testUpdateFileFromFileMessageMaxRetries() throws CoreEntityNotFoundException {
+        //given:
+        when(fileRepository.save(file))
+            .thenThrow(new OptimisticLockingFailureException("Error"));
+
+        //when:
+        assertThatExceptionOfType(OptimisticLockingFailureException.class).isThrownBy(() -> {
+            fileService.updateFileFromFileMessage(fileMessage);
+        });
+
+        //then:
+        verify(fileRepository, times(5)).save(file);
     }
 
 }

--- a/src/main/java/org/humancellatlas/ingest/file/FileService.java
+++ b/src/main/java/org/humancellatlas/ingest/file/FileService.java
@@ -97,12 +97,11 @@ public class FileService {
     @Retryable(
             value = OptimisticLockingFailureException.class,
             maxAttempts = 5,
-            backoff = @Backoff(delay = 500))
+            backoff = @Backoff(delay = 500, maxDelay = 60000, multiplier = 2))
     public File updateFileFromFileMessage(FileMessage fileMessage) throws CoreEntityNotFoundException {
         String envelopeUuid = fileMessage.getStagingAreaId();
         SubmissionEnvelope envelope = findEnvelope(envelopeUuid);
-        File updatedFile = findAndUpdateFile(fileMessage, envelope);
-        return updatedFile;
+        return findAndUpdateFile(fileMessage, envelope);
     }
 
     private File findAndUpdateFile(FileMessage fileMessage, SubmissionEnvelope envelope) {

--- a/src/main/java/org/humancellatlas/ingest/file/web/FileListener.java
+++ b/src/main/java/org/humancellatlas/ingest/file/web/FileListener.java
@@ -11,7 +11,9 @@ import org.humancellatlas.ingest.submission.SubmissionEnvelope;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.amqp.AmqpRejectAndDontRequeueException;
+import org.springframework.amqp.ImmediateRequeueAmqpException;
 import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -38,6 +40,9 @@ public class FileListener {
             } catch (CoreEntityNotFoundException e) {
                 log.warn(e.getMessage());
                 throw new AmqpRejectAndDontRequeueException(e.getMessage());
+            } catch (OptimisticLockingFailureException e){
+                log.warn("Putting file back on queue: " + e.getMessage());
+                throw new ImmediateRequeueAmqpException(e);
             } catch (RuntimeException e) {
                 log.error(e.getMessage());
                 throw new AmqpRejectAndDontRequeueException(e.getMessage());


### PR DESCRIPTION
When processing a message that a file has been added to the staging area.

1. Increase timeout on retry of accepting staging info
2. If the max retry is exceeded, re-queue the file staging message so that it can be tried again.
