### PR TITLE
dcp-944 optimise memory consumption - shallow hashCode

### DIFF
--- a/src/main/java/org/humancellatlas/ingest/biomaterial/Biomaterial.java
+++ b/src/main/java/org/humancellatlas/ingest/biomaterial/Biomaterial.java
@@ -27,7 +27,7 @@ import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
 @CrossOrigin
 @Getter
 @Document
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"project", "projects", "inputToProcesses", "derivedByProcesses"})
 @NoArgsConstructor
 public class Biomaterial extends MetadataDocument {
 

--- a/src/main/java/org/humancellatlas/ingest/core/web/GlobalStateExceptionHandler.java
+++ b/src/main/java/org/humancellatlas/ingest/core/web/GlobalStateExceptionHandler.java
@@ -7,6 +7,7 @@ import org.humancellatlas.ingest.security.exception.NotAllowedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.data.repository.support.QueryMethodParameterConversionException;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -60,7 +61,8 @@ public class GlobalStateExceptionHandler {
             IllegalArgumentException.class,
             HttpMessageNotReadableException.class,
             RedundantUpdateException.class,
-            MultipleOpenSubmissionsException.class
+            MultipleOpenSubmissionsException.class,
+            QueryMethodParameterConversionException.class
     })
     public @ResponseBody
     ExceptionInfo handleIllegalArgument(HttpServletRequest request, Exception e) {
@@ -103,7 +105,7 @@ public class GlobalStateExceptionHandler {
     ExceptionInfo handleRuntimeException(HttpServletRequest request, Exception e) {
         getLog().error(String.format("Runtime exception encountered on %s request to resource %s ", request.getMethod(),
                 request.getRequestURL().toString()), e);
-        getLog().error("Handling RuntimeException and returning INTERNAL_SERVER_ERROR response", e);
+        getLog().error("Handling RuntimeException and returning INTERNAL_SERVER_ERROR response");
         return new ExceptionInfo(request.getRequestURL().toString(), "Unexpected server error");
     }
 

--- a/src/main/java/org/humancellatlas/ingest/file/File.java
+++ b/src/main/java/org/humancellatlas/ingest/file/File.java
@@ -29,7 +29,7 @@ import static com.fasterxml.jackson.annotation.JsonProperty.Access.READ_ONLY;
 @CompoundIndexes({
         @CompoundIndex(name = "validationId", def = "{ 'validationJob.validationId': 1 }")
 })
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"project", "inputToProcesses", "derivedByProcesses"})
 public class File extends MetadataDocument {
 
     @Indexed

--- a/src/main/java/org/humancellatlas/ingest/process/Process.java
+++ b/src/main/java/org/humancellatlas/ingest/process/Process.java
@@ -24,7 +24,7 @@ import java.util.Set;
  * Created by rolando on 16/02/2018.
  */
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"project", "projects", "protocols", "inputBundleManifests", "chainedProcesses"})
 public class Process extends MetadataDocument {
 
     @Indexed

--- a/src/main/java/org/humancellatlas/ingest/project/Project.java
+++ b/src/main/java/org/humancellatlas/ingest/project/Project.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  * @date 30/08/17
  */
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"supplementaryFiles", "submissionEnvelopes"})
 public class Project extends MetadataDocument {
     @RestResource
     @JsonIgnore

--- a/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
+++ b/src/main/java/org/humancellatlas/ingest/protocol/Protocol.java
@@ -13,7 +13,7 @@ import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.DBRef;
 
 @Getter
-@EqualsAndHashCode(callSuper = true)
+@EqualsAndHashCode(callSuper = true, exclude = {"project"})
 @NoArgsConstructor
 public class Protocol extends MetadataDocument {
     @Indexed


### PR DESCRIPTION
change `hashCode` not to traverse DBRef fields to improve efficiency of hashcode calculation by preventing unnecessary db trips.

dcp-944
ebi-ait/dcp-ingest-central#944