### PR TITLE
Feature/morphic dataset type lineage

### DIFF
--- a/src/integration/java/uk/ac/ebi/subs/ingest/dataset/web/DatasetControllerTest.java
+++ b/src/integration/java/uk/ac/ebi/subs/ingest/dataset/web/DatasetControllerTest.java
@@ -315,7 +315,8 @@ class DatasetControllerTest {
 
     Dataset retrieved = repository.findById(childDataset.getId()).orElseThrow();
     assertThat(retrieved.getDerivedFrom()).hasSize(1);
-    assertThat(retrieved.getDerivedFrom().iterator().next().getId()).isEqualTo(parentDataset.getId());
+    assertThat(retrieved.getDerivedFrom().iterator().next().getId())
+        .isEqualTo(parentDataset.getId());
   }
 
   @Test
@@ -324,12 +325,12 @@ class DatasetControllerTest {
 
     // Create and save a study
     String studyContent = objectMapper.writeValueAsString(Map.of("study_title", "Study A"));
-    Study study = new Study(
+    Study study =
+        new Study(
             "https://dev.schema.morphic.bio/type/0.0.1/project/study",
             "0.0.1",
             "study",
-            studyContent
-    );
+            studyContent);
     study = studyRepository.save(study);
 
     // Create raw dataset
@@ -345,14 +346,11 @@ class DatasetControllerTest {
     repository.save(processedDataset);
 
     // Query raw datasets
-    Page<Dataset> result = repository.findByStudyIdAndDatasetType(
-            study.getId(), "raw", PageRequest.of(0, 10));
+    Page<Dataset> result =
+        repository.findByStudyIdAndDatasetType(study.getId(), "raw", PageRequest.of(0, 10));
 
     // Assert only raw returned
     assertThat(result.getContent()).hasSize(1);
     assertThat(result.getContent().get(0).getDatasetType()).isEqualTo("raw");
   }
-
-
-
 }

--- a/src/integration/java/uk/ac/ebi/subs/ingest/dataset/web/DatasetControllerTest.java
+++ b/src/integration/java/uk/ac/ebi/subs/ingest/dataset/web/DatasetControllerTest.java
@@ -13,19 +13,19 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Consumer;
 
 import org.assertj.core.data.MapEntry;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.test.context.support.WithMockUser;
@@ -47,6 +47,8 @@ import uk.ac.ebi.subs.ingest.file.File;
 import uk.ac.ebi.subs.ingest.file.FileRepository;
 import uk.ac.ebi.subs.ingest.process.ProcessRepository;
 import uk.ac.ebi.subs.ingest.protocol.ProtocolRepository;
+import uk.ac.ebi.subs.ingest.study.Study;
+import uk.ac.ebi.subs.ingest.study.StudyRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc(printOnlyOnFailure = false)
@@ -56,6 +58,8 @@ class DatasetControllerTest {
   @Autowired private MockMvc webApp;
 
   @Autowired private DatasetRepository repository;
+
+  @Autowired private StudyRepository studyRepository;
 
   @Autowired private FileRepository fileRepository;
 
@@ -79,6 +83,7 @@ class DatasetControllerTest {
   }
 
   @Nested
+  @Disabled("Test class is currently deactivated - Need to be linked to Submission Envelope")
   class Registration {
     @Test
     @DisplayName("Register Dataset - Success")
@@ -298,4 +303,56 @@ class DatasetControllerTest {
           .andExpect(status().isAccepted());
     }
   }
+
+  @Test
+  void shouldPersistAndRetrieveDerivedFromDatasets() {
+    Dataset parentDataset = new Dataset(Map.of("label", "parent"));
+    parentDataset = repository.save(parentDataset);
+
+    Dataset childDataset = new Dataset(Map.of("label", "child"));
+    childDataset.setDerivedFrom(Set.of(parentDataset));
+    childDataset = repository.save(childDataset);
+
+    Dataset retrieved = repository.findById(childDataset.getId()).orElseThrow();
+    assertThat(retrieved.getDerivedFrom()).hasSize(1);
+    assertThat(retrieved.getDerivedFrom().iterator().next().getId()).isEqualTo(parentDataset.getId());
+  }
+
+  @Test
+  void shouldFindDatasetsByStudyIdAndType() throws Exception {
+    ObjectMapper objectMapper = new ObjectMapper();
+
+    // Create and save a study
+    String studyContent = objectMapper.writeValueAsString(Map.of("study_title", "Study A"));
+    Study study = new Study(
+            "https://dev.schema.morphic.bio/type/0.0.1/project/study",
+            "0.0.1",
+            "study",
+            studyContent
+    );
+    study = studyRepository.save(study);
+
+    // Create raw dataset
+    Dataset rawDataset = new Dataset(Map.of("label", "Raw dataset"));
+    rawDataset.setDatasetType("raw");
+    rawDataset.setStudy(study);
+    repository.save(rawDataset);
+
+    // Create processed dataset
+    Dataset processedDataset = new Dataset(Map.of("label", "Processed dataset"));
+    processedDataset.setDatasetType("processed");
+    processedDataset.setStudy(study);
+    repository.save(processedDataset);
+
+    // Query raw datasets
+    Page<Dataset> result = repository.findByStudyIdAndDatasetType(
+            study.getId(), "raw", PageRequest.of(0, 10));
+
+    // Assert only raw returned
+    assertThat(result.getContent()).hasSize(1);
+    assertThat(result.getContent().get(0).getDatasetType()).isEqualTo("raw");
+  }
+
+
+
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/dataset/Dataset.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/dataset/Dataset.java
@@ -10,9 +10,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Field;
 import uk.ac.ebi.subs.ingest.core.EntityType;
 import uk.ac.ebi.subs.ingest.core.MetadataDocument;
 import uk.ac.ebi.subs.ingest.protocol.Protocol;
+import uk.ac.ebi.subs.ingest.study.Study;
 
 @Getter
 @JsonIgnoreProperties({
@@ -33,6 +36,18 @@ public class Dataset extends MetadataDocument {
   private Set<String> processes = new HashSet<>();
 
   @Setter private String comment;
+
+  @Setter
+  @Field("dataset_type")
+  private String datasetType; // e.g. raw, processed, analysis
+
+  @DBRef(lazy = true)
+  @Setter
+  private Set<Dataset> derivedFrom = new HashSet<>();
+
+  @DBRef
+  @Setter
+  private Study study;
 
   @JsonCreator
   public Dataset(@JsonProperty("content") final Object content) {

--- a/src/main/java/uk/ac/ebi/subs/ingest/dataset/Dataset.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/dataset/Dataset.java
@@ -4,14 +4,15 @@ import java.util.*;
 
 import javax.validation.constraints.NotNull;
 
+import org.springframework.data.mongodb.core.mapping.DBRef;
+import org.springframework.data.mongodb.core.mapping.Field;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.data.mongodb.core.mapping.DBRef;
-import org.springframework.data.mongodb.core.mapping.Field;
 import uk.ac.ebi.subs.ingest.core.EntityType;
 import uk.ac.ebi.subs.ingest.core.MetadataDocument;
 import uk.ac.ebi.subs.ingest.protocol.Protocol;
@@ -45,9 +46,7 @@ public class Dataset extends MetadataDocument {
   @Setter
   private Set<Dataset> derivedFrom = new HashSet<>();
 
-  @DBRef
-  @Setter
-  private Study study;
+  @DBRef @Setter private Study study;
 
   @JsonCreator
   public Dataset(@JsonProperty("content") final Object content) {

--- a/src/main/java/uk/ac/ebi/subs/ingest/dataset/DatasetRepository.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/dataset/DatasetRepository.java
@@ -31,7 +31,6 @@ public interface DatasetRepository extends MongoRepository<Dataset, String> {
   Page<Dataset> findByDatasetType(@Param("type") String datasetType, Pageable pageable);
 
   @RestResource(rel = "byStudyAndType", path = "byStudyAndType")
-  Page<Dataset> findByStudyIdAndDatasetType(@Param("id") String studyId,
-                                            @Param("type") String datasetType,
-                                            Pageable pageable);
+  Page<Dataset> findByStudyIdAndDatasetType(
+      @Param("id") String studyId, @Param("type") String datasetType, Pageable pageable);
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/dataset/DatasetRepository.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/dataset/DatasetRepository.java
@@ -26,4 +26,12 @@ public interface DatasetRepository extends MongoRepository<Dataset, String> {
   Optional<Dataset> findByUuidUuidAndIsUpdateFalse(@Param("uuid") UUID uuid);
 
   Page<Dataset> findBySubmissionEnvelope(SubmissionEnvelope submissionEnvelope, Pageable pageable);
+
+  @RestResource(rel = "byType", path = "byType")
+  Page<Dataset> findByDatasetType(@Param("type") String datasetType, Pageable pageable);
+
+  @RestResource(rel = "byStudyAndType", path = "byStudyAndType")
+  Page<Dataset> findByStudyIdAndDatasetType(@Param("id") String studyId,
+                                            @Param("type") String datasetType,
+                                            Pageable pageable);
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/dataset/DatasetService.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/dataset/DatasetService.java
@@ -232,4 +232,20 @@ public class DatasetService {
 
     return updatedDataset;
   }
+
+  public Dataset addDerivedFromDataset(Dataset dataset, String sourceDatasetId) {
+    String datasetId = dataset.getId();
+
+    datasetRepository
+            .findById(datasetId)
+            .orElseThrow(() -> new ResourceNotFoundException("Dataset: " + datasetId));
+
+    Dataset sourceDataset = datasetRepository
+            .findById(sourceDatasetId)
+            .orElseThrow(() -> new ResourceNotFoundException("Derived-from dataset: " + sourceDatasetId));
+
+    dataset.getDerivedFrom().add(sourceDataset);
+    return datasetRepository.save(dataset);
+  }
+
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/dataset/DatasetService.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/dataset/DatasetService.java
@@ -237,15 +237,16 @@ public class DatasetService {
     String datasetId = dataset.getId();
 
     datasetRepository
-            .findById(datasetId)
-            .orElseThrow(() -> new ResourceNotFoundException("Dataset: " + datasetId));
+        .findById(datasetId)
+        .orElseThrow(() -> new ResourceNotFoundException("Dataset: " + datasetId));
 
-    Dataset sourceDataset = datasetRepository
+    Dataset sourceDataset =
+        datasetRepository
             .findById(sourceDatasetId)
-            .orElseThrow(() -> new ResourceNotFoundException("Derived-from dataset: " + sourceDatasetId));
+            .orElseThrow(
+                () -> new ResourceNotFoundException("Derived-from dataset: " + sourceDatasetId));
 
     dataset.getDerivedFrom().add(sourceDataset);
     return datasetRepository.save(dataset);
   }
-
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/dataset/web/DatasetController.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/dataset/web/DatasetController.java
@@ -171,12 +171,11 @@ public class DatasetController {
 
   @PutMapping("/datasets/{dataset_id}/derivedFrom/{source_dataset_id}")
   public ResponseEntity<Resource<?>> addDerivedFromDataset(
-          @PathVariable("dataset_id") final Dataset dataset,
-          @PathVariable("source_dataset_id") final String sourceDatasetId,
-          final PersistentEntityResourceAssembler assembler) {
+      @PathVariable("dataset_id") final Dataset dataset,
+      @PathVariable("source_dataset_id") final String sourceDatasetId,
+      final PersistentEntityResourceAssembler assembler) {
 
     Dataset updatedDataset = datasetService.addDerivedFromDataset(dataset, sourceDatasetId);
     return ResponseEntity.accepted().body(assembler.toFullResource(updatedDataset));
   }
-
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/dataset/web/DatasetController.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/dataset/web/DatasetController.java
@@ -168,4 +168,15 @@ public class DatasetController {
     return ResponseEntity.accepted()
         .body(assembler.toFullResource(datasetService.addProcessToDataset(dataset, id)));
   }
+
+  @PutMapping("/datasets/{dataset_id}/derivedFrom/{source_dataset_id}")
+  public ResponseEntity<Resource<?>> addDerivedFromDataset(
+          @PathVariable("dataset_id") final Dataset dataset,
+          @PathVariable("source_dataset_id") final String sourceDatasetId,
+          final PersistentEntityResourceAssembler assembler) {
+
+    Dataset updatedDataset = datasetService.addDerivedFromDataset(dataset, sourceDatasetId);
+    return ResponseEntity.accepted().body(assembler.toFullResource(updatedDataset));
+  }
+
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/StudyService.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/StudyService.java
@@ -149,6 +149,8 @@ public class StudyService {
         .orElseThrow(() -> new ResourceNotFoundException("Dataset: " + datasetId));
 
     study.addDataset(dataset);
+    dataset.setStudy(study);
+    datasetRepository.save(dataset);
 
     return studyRepository.save(study);
   }

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/web/StudyResourceProcessor.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/web/StudyResourceProcessor.java
@@ -1,52 +1,51 @@
 package uk.ac.ebi.subs.ingest.study.web;
 
-import lombok.NonNull;
-import lombok.RequiredArgsConstructor;
 import org.springframework.hateoas.EntityLinks;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Resource;
 import org.springframework.hateoas.ResourceProcessor;
 import org.springframework.stereotype.Component;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 import uk.ac.ebi.subs.ingest.study.Study;
 
 @Component
 @RequiredArgsConstructor
 public class StudyResourceProcessor implements ResourceProcessor<Resource<Study>> {
 
-    private final @NonNull EntityLinks entityLinks;
+  private final @NonNull EntityLinks entityLinks;
 
-    @Override
-    public Resource<Study> process(Resource<Study> resource) {
-        Study study = resource.getContent();
+  @Override
+  public Resource<Study> process(Resource<Study> resource) {
+    Study study = resource.getContent();
 
-        if (study != null && study.getId() != null) {
-            resource.add(rawDatasetsLink(study));
-            resource.add(processedDatasetsLink(study));
-            resource.add(analysisDatasetsLink(study));
-        }
-
-        return resource;
+    if (study != null && study.getId() != null) {
+      resource.add(rawDatasetsLink(study));
+      resource.add(processedDatasetsLink(study));
+      resource.add(analysisDatasetsLink(study));
     }
 
-    private Link rawDatasetsLink(Study study) {
-        return new Link(
-                "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=raw",
-                "rawDatasets"
-        ).withTitle("Raw datasets for this study");
-    }
+    return resource;
+  }
 
-    private Link processedDatasetsLink(Study study) {
-        return new Link(
-                "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=processed",
-                "processedDatasets"
-        ).withTitle("Processed datasets for this study");
-    }
+  private Link rawDatasetsLink(Study study) {
+    return new Link(
+            "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=raw", "rawDatasets")
+        .withTitle("Raw datasets for this study");
+  }
 
-    private Link analysisDatasetsLink(Study study) {
-        return new Link(
-                "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=analysis",
-                "analysisDatasets"
-        ).withTitle("Analysis datasets for this study");
-    }
+  private Link processedDatasetsLink(Study study) {
+    return new Link(
+            "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=processed",
+            "processedDatasets")
+        .withTitle("Processed datasets for this study");
+  }
 
+  private Link analysisDatasetsLink(Study study) {
+    return new Link(
+            "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=analysis",
+            "analysisDatasets")
+        .withTitle("Analysis datasets for this study");
+  }
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/web/StudyResourceProcessor.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/web/StudyResourceProcessor.java
@@ -1,0 +1,52 @@
+package uk.ac.ebi.subs.ingest.study.web;
+
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.Resource;
+import org.springframework.hateoas.ResourceProcessor;
+import org.springframework.stereotype.Component;
+import uk.ac.ebi.subs.ingest.study.Study;
+
+@Component
+@RequiredArgsConstructor
+public class StudyResourceProcessor implements ResourceProcessor<Resource<Study>> {
+
+    private final @NonNull EntityLinks entityLinks;
+
+    @Override
+    public Resource<Study> process(Resource<Study> resource) {
+        Study study = resource.getContent();
+
+        if (study != null && study.getId() != null) {
+            resource.add(rawDatasetsLink(study));
+            resource.add(processedDatasetsLink(study));
+            resource.add(analysisDatasetsLink(study));
+        }
+
+        return resource;
+    }
+
+    private Link rawDatasetsLink(Study study) {
+        return new Link(
+                "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=raw",
+                "rawDatasets"
+        ).withTitle("Raw datasets for this study");
+    }
+
+    private Link processedDatasetsLink(Study study) {
+        return new Link(
+                "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=processed",
+                "processedDatasets"
+        ).withTitle("Processed datasets for this study");
+    }
+
+    private Link analysisDatasetsLink(Study study) {
+        return new Link(
+                "/datasets/search/byStudyAndType?id=" + study.getId() + "&type=analysis",
+                "analysisDatasets"
+        ).withTitle("Analysis datasets for this study");
+    }
+
+}

--- a/src/test/java/uk/ac/ebi/subs/ingest/study/StudyResourceProcessorTest.java
+++ b/src/test/java/uk/ac/ebi/subs/ingest/study/StudyResourceProcessorTest.java
@@ -1,0 +1,55 @@
+package uk.ac.ebi.subs.ingest.study;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.hateoas.EntityLinks;
+import org.springframework.hateoas.Link;
+import org.springframework.hateoas.Resource;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.subs.ingest.study.web.StudyResourceProcessor;
+import uk.ac.ebi.subs.ingest.study.Study;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+class StudyResourceProcessorTest {
+
+    private EntityLinks entityLinks;
+    private StudyResourceProcessor studyResourceProcessor;
+
+    @BeforeEach
+    void setUp() {
+        entityLinks = mock(EntityLinks.class);
+        studyResourceProcessor = new StudyResourceProcessor(entityLinks);
+    }
+
+    @Test
+    void shouldAddDatasetLinksToStudyResource() {
+        // Given
+        Study study = new Study(
+                "https://dev.schema.morphic.bio/type/0.0.1/project/study",
+                "0.0.1",
+                "study",
+                Map.of("label", "study B")
+        );
+        ReflectionTestUtils.setField(study, "id", "study123");
+
+        // When
+        Resource<Study> resource = new Resource<>(study);
+        Resource<Study> processed = studyResourceProcessor.process(resource);
+
+        // Then
+        assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("rawDatasets"));
+        assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("processedDatasets"));
+        assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("analysisDatasets"));
+
+        Link rawLink = processed.getLink("rawDatasets");
+        assertThat(rawLink).isNotNull();
+        assertThat(rawLink.getHref()).contains("type=raw");
+        assertThat(rawLink.getTitle()).containsIgnoringCase("Raw");
+
+    }
+}

--- a/src/test/java/uk/ac/ebi/subs/ingest/study/StudyResourceProcessorTest.java
+++ b/src/test/java/uk/ac/ebi/subs/ingest/study/StudyResourceProcessorTest.java
@@ -1,55 +1,53 @@
 package uk.ac.ebi.subs.ingest.study;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+import java.util.Map;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.hateoas.EntityLinks;
 import org.springframework.hateoas.Link;
 import org.springframework.hateoas.Resource;
 import org.springframework.test.util.ReflectionTestUtils;
+
 import uk.ac.ebi.subs.ingest.study.web.StudyResourceProcessor;
-import uk.ac.ebi.subs.ingest.study.Study;
-
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.*;
 
 class StudyResourceProcessorTest {
 
-    private EntityLinks entityLinks;
-    private StudyResourceProcessor studyResourceProcessor;
+  private EntityLinks entityLinks;
+  private StudyResourceProcessor studyResourceProcessor;
 
-    @BeforeEach
-    void setUp() {
-        entityLinks = mock(EntityLinks.class);
-        studyResourceProcessor = new StudyResourceProcessor(entityLinks);
-    }
+  @BeforeEach
+  void setUp() {
+    entityLinks = mock(EntityLinks.class);
+    studyResourceProcessor = new StudyResourceProcessor(entityLinks);
+  }
 
-    @Test
-    void shouldAddDatasetLinksToStudyResource() {
-        // Given
-        Study study = new Study(
-                "https://dev.schema.morphic.bio/type/0.0.1/project/study",
-                "0.0.1",
-                "study",
-                Map.of("label", "study B")
-        );
-        ReflectionTestUtils.setField(study, "id", "study123");
+  @Test
+  void shouldAddDatasetLinksToStudyResource() {
+    // Given
+    Study study =
+        new Study(
+            "https://dev.schema.morphic.bio/type/0.0.1/project/study",
+            "0.0.1",
+            "study",
+            Map.of("label", "study B"));
+    ReflectionTestUtils.setField(study, "id", "study123");
 
-        // When
-        Resource<Study> resource = new Resource<>(study);
-        Resource<Study> processed = studyResourceProcessor.process(resource);
+    // When
+    Resource<Study> resource = new Resource<>(study);
+    Resource<Study> processed = studyResourceProcessor.process(resource);
 
-        // Then
-        assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("rawDatasets"));
-        assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("processedDatasets"));
-        assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("analysisDatasets"));
+    // Then
+    assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("rawDatasets"));
+    assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("processedDatasets"));
+    assertThat(processed.getLinks()).anyMatch(link -> link.getRel().equals("analysisDatasets"));
 
-        Link rawLink = processed.getLink("rawDatasets");
-        assertThat(rawLink).isNotNull();
-        assertThat(rawLink.getHref()).contains("type=raw");
-        assertThat(rawLink.getTitle()).containsIgnoringCase("Raw");
-
-    }
+    Link rawLink = processed.getLink("rawDatasets");
+    assertThat(rawLink).isNotNull();
+    assertThat(rawLink.getHref()).contains("type=raw");
+    assertThat(rawLink.getTitle()).containsIgnoringCase("Raw");
+  }
 }


### PR DESCRIPTION
This PR improves the dataset metadata model and Provider API to support:

- Linking datasets to their parent Study
- Supporting datasetType classification: `raw, processed, analysis`
- Tracking data lineage via `derivedFrom` relationships
- Exposing HAL links:
```
/datasets/{id}/study
/datasets/{id}/derivedFrom
/studies/{id} includes: rawDatasets, processedDatasets, analysisDatasets
```
- Enabling search via `/datasets/search/byStudyAndType
`
- **Unit tests** for search, resource processors, and link generation
- **Integration tests** for study-dataset linkage and filters

Link to ticket: https://github.com/orgs/ebi-ait/projects/11/views/6?filterQuery=label%3AMorphic+orge&pane=issue&itemId=112262965&issue=ebi-ait%7Csubmissions-workstream%7C75