### PR TITLE
Use Gene Search API to populate each study with new_target_genes

### DIFF
--- a/CI/.morphic-gitlab-ci.yml
+++ b/CI/.morphic-gitlab-ci.yml
@@ -94,6 +94,14 @@ deploy-dev:
     - export AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
     - aws eks update-kubeconfig --name $EKS_CLUSTER_NAME --region $AWS_DEFAULT_REGION
   script:
+    # 1) Decode base64 and upsert Secret (no printing of value)
+    - |
+      DECODED_URI="$(echo "$SPRING_DATA_MONGODB_URI_DEV" | base64 -d)"
+      kubectl -n morphic-dev create secret generic ingest-core-secrets \
+        --from-literal=SPRING_DATA_MONGODB_URI="$DECODED_URI" \
+        --dry-run=client -o yaml | kubectl -n morphic-dev apply -f -
+      unset DECODED_URI
+    # 2) Inject image tag and apply manifests
     - sed -i "s|{{IMAGE}}|$AWS_ACCOUNT_ID.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/ingest-core-morphic:$CI_COMMIT_SHA|g" CI/ingest-core-morphic-deployment-dev.yaml
     - kubectl apply -f CI/ingest-core-morphic-deployment-dev.yaml
     - kubectl apply -f CI/ingest-core-morphic-service.yaml -n morphic-dev
@@ -113,6 +121,12 @@ deploy-prod:
     - export AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION
     - aws eks update-kubeconfig --name $EKS_CLUSTER_NAME_PROD --region $AWS_DEFAULT_REGION
   script:
+    - |
+      DECODED_URI="$(echo "$SPRING_DATA_MONGODB_URI_PROD" | base64 -d)"
+      kubectl -n morphic-prod create secret generic ingest-core-secrets \
+        --from-literal=SPRING_DATA_MONGODB_URI="$DECODED_URI" \
+        --dry-run=client -o yaml | kubectl -n morphic-prod apply -f -
+      unset DECODED_URI
     - sed -i "s|{{IMAGE}}|$AWS_ACCOUNT_ID_PROD.dkr.ecr.$AWS_DEFAULT_REGION.amazonaws.com/ingest-core-morphic:$CI_COMMIT_SHA|g" CI/ingest-core-morphic-deployment-prod.yaml
     - kubectl apply -f CI/ingest-core-morphic-deployment-prod.yaml
     - kubectl apply -f CI/ingest-core-morphic-service.yaml -n morphic-prod

--- a/CI/ingest-core-morphic-deployment-dev.yaml
+++ b/CI/ingest-core-morphic-deployment-dev.yaml
@@ -21,8 +21,11 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: local
-            - name: MONGO_URI
-              value: mongodb+srv://morphic-dev:mDev12345@morphicdevcluster.jduoa8p.mongodb.net/MorphicDev?retryWrites=true&w=majority
+            - name: SPRING_DATA_MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: ingest-core-secrets
+                  key: SPRING_DATA_MONGODB_URI
             - name: RABBIT_HOST
               value: rabbitmq-service
             - name: RABBIT_PORT

--- a/CI/ingest-core-morphic-deployment-prod.yaml
+++ b/CI/ingest-core-morphic-deployment-prod.yaml
@@ -21,8 +21,11 @@ spec:
           env:
             - name: SPRING_PROFILES_ACTIVE
               value: prod
-            - name: MONGO_URI
-              value: mongodb+srv://morphic-prod:morphicProd#12345@morphicprodcluster.gvr5bkw.mongodb.net/MorphicProd?retryWrites=true&w=majority
+            - name: SPRING_DATA_MONGODB_URI
+              valueFrom:
+                secretKeyRef:
+                  name: ingest-core-secrets
+                  key: SPRING_DATA_MONGODB_URI
             - name: RABBIT_HOST
               value: rabbitmq-service
             - name: RABBIT_PORT

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ spotless {
         googleJavaFormat()
         removeUnusedImports()
         importOrder 'java', 'javax', 'org', 'com'
+        lineEndings 'UNIX'
     }
 }
 

--- a/src/main/java/uk/ac/ebi/subs/ingest/gene/GeneSearchClient.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/gene/GeneSearchClient.java
@@ -1,81 +1,69 @@
 package uk.ac.ebi.subs.ingest.gene;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
-import reactor.core.publisher.Mono;
-
-import org.springframework.boot.web.client.RestTemplateBuilder;
-import org.springframework.stereotype.Component;
-import org.springframework.web.client.RestTemplate;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
-  * Lightweight client that turns a gene symbol (e.g. "BHLHE40")
-  * into its HGNC identifier ("HGNC:1046") by calling the external
-  * Lambda endpoint defined in application-*.properties:
-  *
-  *   gene.api.base = https://46ucfedadd.execute-api.us-east-1.amazonaws.com/api
- **/
+ * Lightweight client that turns a gene symbol (e.g. "BHLHE40") into its HGNC identifier
+ * ("HGNC:1046") by calling the external Lambda endpoint defined in application-*.properties:
+ *
+ * <p>gene.api.base = https://46ucfedadd.execute-api.us-east-1.amazonaws.com/api
+ */
 @Slf4j
 @Component
 public class GeneSearchClient {
 
-    private final String geneApiBase;
-    private final RestTemplate rest;
+  private final String geneApiBase;
+  private final RestTemplate rest;
 
-    public GeneSearchClient(@Value("${gene.api.base}") String geneApiBase, RestTemplateBuilder builder) {
-        this.geneApiBase = geneApiBase.replaceAll("/+$", "");
-        this.rest        = builder.build();
+  public GeneSearchClient(
+      @Value("${gene.api.base}") String geneApiBase, RestTemplateBuilder builder) {
+    this.geneApiBase = geneApiBase.replaceAll("/+$", "");
+    this.rest = builder.build();
+  }
+
+  public Optional<String> symbolToHgncId(String symbol) {
+
+    String url = String.format("%s/gene-search?query=%s", geneApiBase, symbol);
+    log.debug("► GET {}", url);
+
+    try {
+      ResponseEntity<List<Map<String, Object>>> resp =
+          rest.exchange(
+              url,
+              HttpMethod.GET,
+              null,
+              new ParameterizedTypeReference<List<Map<String, Object>>>() {});
+
+      List<Map<String, Object>> list = resp.getBody();
+
+      if (resp.getStatusCode().is2xxSuccessful() && list != null && !list.isEmpty()) {
+
+        String hgnc = (String) list.get(0).get("HGNC_ID");
+        log.debug("{} → {}", symbol, hgnc);
+        return Optional.ofNullable(hgnc);
+      }
+      log.warn("No match for {}", symbol);
+      return Optional.empty();
+
+    } catch (Exception ex) {
+      log.warn("{} : {}", symbol, ex.getMessage());
+      return Optional.empty();
     }
+  }
 
-    public Optional<String> symbolToHgncId(String symbol) {
-
-        String url = String.format("%s/gene-search?query=%s", geneApiBase, symbol);
-        log.debug("► GET {}", url);
-
-        try {
-            ResponseEntity<List<Map<String, Object>>> resp =
-                    rest.exchange(
-                            url,
-                            HttpMethod.GET,
-                            null,
-                            new ParameterizedTypeReference<List<Map<String, Object>>>() {});
-
-            List<Map<String, Object>> list = resp.getBody();
-
-            if (resp.getStatusCode().is2xxSuccessful()
-                    && list != null && !list.isEmpty()) {
-
-                String hgnc = (String) list.get(0).get("HGNC_ID");
-                log.debug("{} → {}", symbol, hgnc);
-                return Optional.ofNullable(hgnc);
-            }
-            log.warn("No match for {}", symbol);
-            return Optional.empty();
-
-        }
-
-        catch (Exception ex) {
-            log.warn("{} : {}", symbol, ex.getMessage());
-            return Optional.empty();
-        }
-    }
-
-    public String buildGeneUrl(String hgncId) {
-        return String.format("%s/gene/%s", geneApiBase, hgncId);
-    }
+  public String buildGeneUrl(String hgncId) {
+    return String.format("%s/gene/%s", geneApiBase, hgncId);
+  }
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/gene/GeneSearchClient.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/gene/GeneSearchClient.java
@@ -1,0 +1,81 @@
+package uk.ac.ebi.subs.ingest.gene;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+
+/**
+  * Lightweight client that turns a gene symbol (e.g. "BHLHE40")
+  * into its HGNC identifier ("HGNC:1046") by calling the external
+  * Lambda endpoint defined in application-*.properties:
+  *
+  *   gene.api.base = https://46ucfedadd.execute-api.us-east-1.amazonaws.com/api
+ **/
+@Slf4j
+@Component
+public class GeneSearchClient {
+
+    private final String geneApiBase;
+    private final RestTemplate rest;
+
+    public GeneSearchClient(@Value("${gene.api.base}") String geneApiBase, RestTemplateBuilder builder) {
+        this.geneApiBase = geneApiBase.replaceAll("/+$", "");
+        this.rest        = builder.build();
+    }
+
+    public Optional<String> symbolToHgncId(String symbol) {
+
+        String url = String.format("%s/gene-search?query=%s", geneApiBase, symbol);
+        log.debug("► GET {}", url);
+
+        try {
+            ResponseEntity<List<Map<String, Object>>> resp =
+                    rest.exchange(
+                            url,
+                            HttpMethod.GET,
+                            null,
+                            new ParameterizedTypeReference<List<Map<String, Object>>>() {});
+
+            List<Map<String, Object>> list = resp.getBody();
+
+            if (resp.getStatusCode().is2xxSuccessful()
+                    && list != null && !list.isEmpty()) {
+
+                String hgnc = (String) list.get(0).get("HGNC_ID");
+                log.debug("{} → {}", symbol, hgnc);
+                return Optional.ofNullable(hgnc);
+            }
+            log.warn("No match for {}", symbol);
+            return Optional.empty();
+
+        }
+
+        catch (Exception ex) {
+            log.warn("{} : {}", symbol, ex.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    public String buildGeneUrl(String hgncId) {
+        return String.format("%s/gene/%s", geneApiBase, hgncId);
+    }
+}

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/Study.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/Study.java
@@ -24,6 +24,9 @@ import uk.ac.ebi.subs.ingest.core.MetadataDocument;
 import uk.ac.ebi.subs.ingest.dataset.Dataset;
 import uk.ac.ebi.subs.ingest.submission.SubmissionEnvelope;
 
+import java.util.Collections;
+import java.util.Map;
+
 @Getter
 @EqualsAndHashCode(
     callSuper = true,
@@ -118,5 +121,30 @@ public class Study extends MetadataDocument implements DescriptiveSchema {
     return this.submissionEnvelopes.stream()
         .filter(Objects::nonNull)
         .allMatch(SubmissionEnvelope::isEditable);
+  }
+
+  @JsonIgnore
+  @SuppressWarnings("unchecked")
+  public Map<String, Object> getContentMap() {
+    // use the inherited getter – *not* the field
+    Object raw = getContent();          // <- this compiles
+
+    return (raw instanceof Map)
+            ? (Map<String, Object>) raw
+            : Collections.emptyMap();
+  }
+  @JsonIgnore
+  public List<String> getTargetGenes() {
+    Object raw = getContentMap().get("target_genes");
+
+    if (raw instanceof List<?>) {
+      return ((List<?>) raw).stream()
+              .map(Object::toString)
+              .collect(Collectors.toList());
+    }
+    if (raw instanceof String) {
+      return List.of(raw.toString());
+    }
+    return Collections.emptyList();
   }
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/Study.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/Study.java
@@ -1,7 +1,9 @@
 package uk.ac.ebi.subs.ingest.study;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -23,9 +25,6 @@ import uk.ac.ebi.subs.ingest.core.EntityType;
 import uk.ac.ebi.subs.ingest.core.MetadataDocument;
 import uk.ac.ebi.subs.ingest.dataset.Dataset;
 import uk.ac.ebi.subs.ingest.submission.SubmissionEnvelope;
-
-import java.util.Collections;
-import java.util.Map;
 
 @Getter
 @EqualsAndHashCode(
@@ -127,20 +126,17 @@ public class Study extends MetadataDocument implements DescriptiveSchema {
   @SuppressWarnings("unchecked")
   public Map<String, Object> getContentMap() {
     // use the inherited getter – *not* the field
-    Object raw = getContent();          // <- this compiles
+    Object raw = getContent(); // <- this compiles
 
-    return (raw instanceof Map)
-            ? (Map<String, Object>) raw
-            : Collections.emptyMap();
+    return (raw instanceof Map) ? (Map<String, Object>) raw : Collections.emptyMap();
   }
+
   @JsonIgnore
   public List<String> getTargetGenes() {
     Object raw = getContentMap().get("target_genes");
 
     if (raw instanceof List<?>) {
-      return ((List<?>) raw).stream()
-              .map(Object::toString)
-              .collect(Collectors.toList());
+      return ((List<?>) raw).stream().map(Object::toString).collect(Collectors.toList());
     }
     if (raw instanceof String) {
       return List.of(raw.toString());

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/api/GeneRef.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/api/GeneRef.java
@@ -1,0 +1,20 @@
+package uk.ac.ebi.subs.ingest.study.api;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Value;
+
+/** one entry inside the “target_genes” array */
+@Value
+public class GeneRef {
+
+    String symbol;
+    String href;        // may be null when we can’t resolve the gene
+
+    /** let Jackson use the generated all-args constructor */
+    @JsonCreator
+    public GeneRef(@JsonProperty("symbol") String symbol,
+                   @JsonProperty("href")   String href) {
+        this.symbol = symbol;
+        this.href   = href;
+    }
+}

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/api/GeneRef.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/api/GeneRef.java
@@ -1,20 +1,21 @@
 package uk.ac.ebi.subs.ingest.study.api;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Value;
 
 /** one entry inside the “target_genes” array */
 @Value
 public class GeneRef {
 
-    String symbol;
-    String href;        // may be null when we can’t resolve the gene
+  String symbol;
+  String href; // may be null when we can’t resolve the gene
 
-    /** let Jackson use the generated all-args constructor */
-    @JsonCreator
-    public GeneRef(@JsonProperty("symbol") String symbol,
-                   @JsonProperty("href")   String href) {
-        this.symbol = symbol;
-        this.href   = href;
-    }
+  /** let Jackson use the generated all-args constructor */
+  @JsonCreator
+  public GeneRef(@JsonProperty("symbol") String symbol, @JsonProperty("href") String href) {
+    this.symbol = symbol;
+    this.href = href;
+  }
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/api/StudyDto.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/api/StudyDto.java
@@ -1,20 +1,21 @@
 package uk.ac.ebi.subs.ingest.study.api;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
-import lombok.Value;
-import uk.ac.ebi.subs.ingest.study.Study;
 
 import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import lombok.Value;
+import uk.ac.ebi.subs.ingest.study.Study;
 
 /** complete payload returned by GET /studies/{id} */
 @Value
 public class StudyDto {
 
-    /** keep every field of {@link Study} at the top JSON level */
-    @JsonUnwrapped
-    Study study;
+  /** keep every field of {@link Study} at the top JSON level */
+  @JsonUnwrapped Study study;
 
-    /** replace the old String[] with the enriched objects */
-    @JsonProperty("new_target_genes")        // keep the original key
-    List<GeneRef> targetGenes;
+  /** replace the old String[] with the enriched objects */
+  @JsonProperty("new_target_genes") // keep the original key
+  List<GeneRef> targetGenes;
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/api/StudyDto.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/api/StudyDto.java
@@ -1,0 +1,20 @@
+package uk.ac.ebi.subs.ingest.study.api;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import lombok.Value;
+import uk.ac.ebi.subs.ingest.study.Study;
+
+import java.util.List;
+
+/** complete payload returned by GET /studies/{id} */
+@Value
+public class StudyDto {
+
+    /** keep every field of {@link Study} at the top JSON level */
+    @JsonUnwrapped
+    Study study;
+
+    /** replace the old String[] with the enriched objects */
+    @JsonProperty("new_target_genes")        // keep the original key
+    List<GeneRef> targetGenes;
+}

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/web/StudyController.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/web/StudyController.java
@@ -26,11 +26,22 @@ import uk.ac.ebi.subs.ingest.study.StudyRepository;
 import uk.ac.ebi.subs.ingest.study.StudyService;
 import uk.ac.ebi.subs.ingest.submission.SubmissionEnvelope;
 import uk.ac.ebi.subs.ingest.submission.exception.NotAllowedDuringSubmissionStateException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.hateoas.Link;
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
+import uk.ac.ebi.subs.ingest.gene.GeneSearchClient;
+import uk.ac.ebi.subs.ingest.study.api.StudyDto;
+import uk.ac.ebi.subs.ingest.study.api.GeneRef;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+
 
 @RepositoryRestController
 @ExposesResourceFor(Study.class)
 @RequiredArgsConstructor
 @Getter
+@Slf4j
 /*
 Controller for studies
  */
@@ -38,6 +49,8 @@ public class StudyController {
   private static final Logger LOGGER = LoggerFactory.getLogger(StudyController.class);
   private final @NonNull StudyService studyService;
   private final @NonNull StudyRepository studyRepository;
+  private final GeneSearchClient geneClient;
+  @Value("${gene.api.base}") private String geneApiBase;
 
   @PatchMapping("/studies/{studyId}")
   public ResponseEntity<Resource<?>> updateStudy(
@@ -105,5 +118,26 @@ public class StudyController {
       final PersistentEntityResourceAssembler assembler) {
     return ResponseEntity.accepted()
         .body(assembler.toFullResource(getStudyService().linkDatasetToStudy(study, dataset)));
+  }
+
+  @GetMapping("/studies/{studyId}")
+  public ResponseEntity<StudyDto> getStudy(@PathVariable String studyId) {
+    return Optional.ofNullable(studyService.findById(studyId))
+            .map(study -> {
+
+              // ---------------- build the enriched list ----------------
+              log.debug("Loaded Study {}, targetGenes = {}", studyId, study.getTargetGenes());
+              List<GeneRef> enriched = study.getTargetGenes().stream()
+                      .map(symbol ->
+                              geneClient.symbolToHgncId(symbol)          // Optional<String>
+                                      .map(id -> new GeneRef(symbol, geneClient.buildGeneUrl(id)))
+                                      .orElse(new GeneRef(symbol, null))
+                      )
+                      .collect(Collectors.toList());
+              // --------------------------------------------------------
+              log.debug("After enrichment Study {}", new StudyDto(study, enriched));
+              return ResponseEntity.ok(new StudyDto(study, enriched));
+            })
+            .orElseGet(() -> ResponseEntity.notFound().build());
   }
 }

--- a/src/main/java/uk/ac/ebi/subs/ingest/study/web/StudyController.java
+++ b/src/main/java/uk/ac/ebi/subs/ingest/study/web/StudyController.java
@@ -1,10 +1,15 @@
 package uk.ac.ebi.subs.ingest.study.web;
 
+import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
+
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.rest.webmvc.PersistentEntityResource;
 import org.springframework.data.rest.webmvc.PersistentEntityResourceAssembler;
 import org.springframework.data.rest.webmvc.RepositoryRestController;
@@ -18,24 +23,18 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import uk.ac.ebi.subs.ingest.core.Uuid;
 import uk.ac.ebi.subs.ingest.dataset.Dataset;
+import uk.ac.ebi.subs.ingest.gene.GeneSearchClient;
 import uk.ac.ebi.subs.ingest.security.CheckAllowed;
 import uk.ac.ebi.subs.ingest.study.Study;
 import uk.ac.ebi.subs.ingest.study.StudyRepository;
 import uk.ac.ebi.subs.ingest.study.StudyService;
+import uk.ac.ebi.subs.ingest.study.api.GeneRef;
+import uk.ac.ebi.subs.ingest.study.api.StudyDto;
 import uk.ac.ebi.subs.ingest.submission.SubmissionEnvelope;
 import uk.ac.ebi.subs.ingest.submission.exception.NotAllowedDuringSubmissionStateException;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.hateoas.Link;
-import static org.springframework.hateoas.mvc.ControllerLinkBuilder.*;
-import uk.ac.ebi.subs.ingest.gene.GeneSearchClient;
-import uk.ac.ebi.subs.ingest.study.api.StudyDto;
-import uk.ac.ebi.subs.ingest.study.api.GeneRef;
-import java.util.List;
-import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
-
 
 @RepositoryRestController
 @ExposesResourceFor(Study.class)
@@ -50,7 +49,9 @@ public class StudyController {
   private final @NonNull StudyService studyService;
   private final @NonNull StudyRepository studyRepository;
   private final GeneSearchClient geneClient;
-  @Value("${gene.api.base}") private String geneApiBase;
+
+  @Value("${gene.api.base}")
+  private String geneApiBase;
 
   @PatchMapping("/studies/{studyId}")
   public ResponseEntity<Resource<?>> updateStudy(
@@ -123,21 +124,24 @@ public class StudyController {
   @GetMapping("/studies/{studyId}")
   public ResponseEntity<StudyDto> getStudy(@PathVariable String studyId) {
     return Optional.ofNullable(studyService.findById(studyId))
-            .map(study -> {
+        .map(
+            study -> {
 
               // ---------------- build the enriched list ----------------
               log.debug("Loaded Study {}, targetGenes = {}", studyId, study.getTargetGenes());
-              List<GeneRef> enriched = study.getTargetGenes().stream()
-                      .map(symbol ->
-                              geneClient.symbolToHgncId(symbol)          // Optional<String>
-                                      .map(id -> new GeneRef(symbol, geneClient.buildGeneUrl(id)))
-                                      .orElse(new GeneRef(symbol, null))
-                      )
+              List<GeneRef> enriched =
+                  study.getTargetGenes().stream()
+                      .map(
+                          symbol ->
+                              geneClient
+                                  .symbolToHgncId(symbol) // Optional<String>
+                                  .map(id -> new GeneRef(symbol, geneClient.buildGeneUrl(id)))
+                                  .orElse(new GeneRef(symbol, null)))
                       .collect(Collectors.toList());
               // --------------------------------------------------------
               log.debug("After enrichment Study {}", new StudyDto(study, enriched));
               return ResponseEntity.ok(new StudyDto(study, enriched));
             })
-            .orElseGet(() -> ResponseEntity.notFound().build());
+        .orElseGet(() -> ResponseEntity.notFound().build());
   }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,7 +1,6 @@
 # use this application properties profile for running locally
 # with a local mongodb and rabbitmq
 # i.e. -Dspring.profile.active=local
-#spring.main.banner-mode=off
 AUTH_ISSUER=https://login.elixir-czech.org/oidc/
 GCP_JWK_PROVIDER_BASE_URL=https://www.googleapis.com/service_accounts/v1/jwk/
 GCP_PROJECT_WHITELIST=hca-dcp-production.iam.gserviceaccount.com,human-cell-atlas-travis-test.iam.gserviceaccount.com,broad-dsde-mint-dev.iam.gserviceaccount.com,broad-dsde-mint-test.iam.gserviceaccount.com,broad-dsde-mint-staging.iam.gserviceaccount.com
@@ -9,7 +8,13 @@ SCHEMA_BASE_URI=https://dev.schema.morphic.bio/
 SVC_AUTH_AUDIENCE=https://dev.data.humancellatlas.org/
 USR_AUTH_AUDIENCE=https://dev.data.humancellatlas.org/
 schema.base-uri=https://dev.schema.morphic.bio/
-spring.data.mongodb.uri=mongodb+srv://morphic-dev:mDev12345@morphicdevcluster.jduoa8p.mongodb.net/MorphicDev?retryWrites=true&w=majority
+
+# Set this in your environment before running:
+# export MONGO_URI="mongodb+srv://user:password@cluster.mongodb.net/MorphicDev?retryWrites=true&w=majority"
+# Spring will automatically substitute ${MONGO_URI} with your env variable.
+spring.data.mongodb.uri=${MONGO_URI}
+#spring.data.mongodb.uri=mongodb://localhost:27017/ingest
+
 spring.rabbitmq.host=localhost
 spring.rabbitmq.port=5672
 # display mongo queries
@@ -18,9 +23,3 @@ spring.rabbitmq.port=5672
 # display security messages
 logging.level.org.springframework.security.access.expression.method=DEBUG
 logging.level.org.springframework.security=DEBUG
-gene.api.base = https://46ucfedadd.execute-api.us-east-1.amazonaws.com/api
-
-management.health.mongo.enabled=false
-logging.level.uk.ac.ebi.subs.ingest.study.web=DEBUG
-logging.level.uk.ac.ebi.subs.ingest.gene=DEBUG
-

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -1,6 +1,7 @@
 # use this application properties profile for running locally
 # with a local mongodb and rabbitmq
 # i.e. -Dspring.profile.active=local
+#spring.main.banner-mode=off
 AUTH_ISSUER=https://login.elixir-czech.org/oidc/
 GCP_JWK_PROVIDER_BASE_URL=https://www.googleapis.com/service_accounts/v1/jwk/
 GCP_PROJECT_WHITELIST=hca-dcp-production.iam.gserviceaccount.com,human-cell-atlas-travis-test.iam.gserviceaccount.com,broad-dsde-mint-dev.iam.gserviceaccount.com,broad-dsde-mint-test.iam.gserviceaccount.com,broad-dsde-mint-staging.iam.gserviceaccount.com
@@ -17,3 +18,9 @@ spring.rabbitmq.port=5672
 # display security messages
 logging.level.org.springframework.security.access.expression.method=DEBUG
 logging.level.org.springframework.security=DEBUG
+gene.api.base = https://46ucfedadd.execute-api.us-east-1.amazonaws.com/api
+
+management.health.mongo.enabled=false
+logging.level.uk.ac.ebi.subs.ingest.study.web=DEBUG
+logging.level.uk.ac.ebi.subs.ingest.gene=DEBUG
+


### PR DESCRIPTION
This PR introduces `new_target_genes` that has a link to the gene and it's corresponding HGNC:ID lookup within each Study. I think this can be refactored to be part of the `target_genes`, please suggest any other edits as necessary.  